### PR TITLE
INTYGFV-11955: Use correct access method when validating if user is a…

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/access/CertificateAccessService.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/access/CertificateAccessService.java
@@ -69,22 +69,6 @@ public interface CertificateAccessService {
     AccessResult allowToRenew(String certificateType, Vardenhet careUnit, Personnummer patient);
 
     /**
-     * Check if the user is allowed to renew a certificate.
-     *
-     * @param certificateType
-     *            The type of the certificate being checked.
-     * @param careUnit
-     *            The careUnit which the certificate belongs to.
-     * @param patient
-     *            The patient which the certificate belongs to.
-     * @param complement
-     *            If the renewal is a complement
-     * @return
-     *         AccessResult which contains the answer if the user is allowed or not.
-     */
-    AccessResult allowToRenew(String certificateType, Vardenhet careUnit, Personnummer patient, boolean complement);
-
-    /**
      * Check if the user is allowed to print a certificate.
      *
      * @param certificateType

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/access/CertificateAccessServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/access/CertificateAccessServiceImpl.java
@@ -87,15 +87,9 @@ public class CertificateAccessServiceImpl implements CertificateAccessService {
 
     @Override
     public AccessResult allowToRenew(String certificateType, Vardenhet careUnit, Personnummer patient) {
-        return allowToRenew(certificateType, careUnit, patient, false);
-    }
-
-    @Override
-    public AccessResult allowToRenew(String certificateType, Vardenhet careUnit, Personnummer patient, boolean isComplement) {
         return getAccessServiceEvaluation().given(getUser(), certificateType)
                 .feature(AuthoritiesConstants.FEATURE_FORNYA_INTYG)
                 .privilege(AuthoritiesConstants.PRIVILEGE_FORNYA_INTYG)
-                .privilegeIf(AuthoritiesConstants.PRIVILEGE_SVARA_MED_NYTT_INTYG, isComplement)
                 .careUnit(careUnit)
                 .patient(patient)
                 .checkPatientDeceased(false)

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/CopyUtkastServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/CopyUtkastServiceImpl.java
@@ -184,7 +184,7 @@ public class CopyUtkastServiceImpl implements CopyUtkastService {
                     coherentJournaling,
                     false);
 
-            validateAccessToRenewIntyg(utlatande, true);
+            validateAccessToComplementIntyg(utlatande);
 
             if (intygService.isRevoked(copyRequest.getOriginalIntygId(), copyRequest.getTyp(), false)) {
                 LOG.debug("Cannot create completion copy of certificate with id '{}', the certificate is revoked", originalIntygId);
@@ -232,7 +232,7 @@ public class CopyUtkastServiceImpl implements CopyUtkastService {
                     coherentJournaling,
                     false);
 
-            validateAccessToRenewIntyg(utlatande, false);
+            validateAccessToRenewIntyg(utlatande);
 
             if (intygService.isRevoked(copyRequest.getOriginalIntygId(), copyRequest.getOriginalIntygTyp(), coherentJournaling)) {
                 LOG.debug("Cannot renew certificate with id '{}', the certificate is revoked", originalIntygId);
@@ -671,12 +671,21 @@ public class CopyUtkastServiceImpl implements CopyUtkastService {
         integreradeEnheterRegistry.addIfSameVardgivareButDifferentUnits(orginalEnhetsId, newEntry, utkastCopy.getIntygsTyp());
     }
 
-    private void validateAccessToRenewIntyg(Utlatande utlatande, boolean complement) {
+    private void validateAccessToRenewIntyg(Utlatande utlatande) {
         final AccessResult accessResult = certificateAccessService.allowToRenew(
                 utlatande.getTyp(),
                 getVardenhet(utlatande),
+                getPersonnummer(utlatande));
+
+        accessResultExceptionHelper.throwExceptionIfDenied(accessResult);
+    }
+
+    private void validateAccessToComplementIntyg(Utlatande utlatande) {
+        final AccessResult accessResult = certificateAccessService.allowToAnswerComplementQuestion(
+                utlatande.getTyp(),
+                getVardenhet(utlatande),
                 getPersonnummer(utlatande),
-                complement);
+                true);
 
         accessResultExceptionHelper.throwExceptionIfDenied(accessResult);
     }

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/util/resourcelinks/ResourceLinkHelperImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/util/resourcelinks/ResourceLinkHelperImpl.java
@@ -115,7 +115,7 @@ public class ResourceLinkHelperImpl implements ResourceLinkHelper {
         final Vardenhet vardenhet = intygContentHolder.getUtlatande().getGrundData().getSkapadAv().getVardenhet();
         final Personnummer personnummer = intygContentHolder.getUtlatande().getGrundData().getPatient().getPersonId();
 
-        if (certificateAccessService.allowToRenew(intygsTyp, vardenhet, personnummer, false).isAllowed()) {
+        if (certificateAccessService.allowToRenew(intygsTyp, vardenhet, personnummer).isAllowed()) {
             intygContentHolder.addLink(new ActionLink(ActionLinkType.FORNYA_INTYG));
         }
 
@@ -159,7 +159,7 @@ public class ResourceLinkHelperImpl implements ResourceLinkHelper {
             listIntygEntry.addLink(new ActionLink(ActionLinkType.LASA_INTYG));
         }
 
-        if (certificateAccessService.allowToRenew(listIntygEntry.getIntygType(), vardenhet, patient, false).isAllowed()) {
+        if (certificateAccessService.allowToRenew(listIntygEntry.getIntygType(), vardenhet, patient).isAllowed()) {
             listIntygEntry.addLink(new ActionLink(ActionLinkType.FORNYA_INTYG));
         }
     }

--- a/web/src/test/java/se/inera/intyg/webcert/web/web/util/resourcelink/ResourceLinkHelperImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/web/util/resourcelink/ResourceLinkHelperImplTest.java
@@ -22,7 +22,6 @@ package se.inera.intyg.webcert.web.web.util.resourcelink;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -253,7 +252,7 @@ public class ResourceLinkHelperImplTest {
         final Personnummer patient = Personnummer.createPersonnummer("191212121212").get();
         final Vardenhet vardenhet = mock(Vardenhet.class);
 
-        doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToRenew(intygsTyp, vardenhet, patient, false);
+        doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToRenew(intygsTyp, vardenhet, patient);
         doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToInvalidate(intygsTyp, vardenhet, patient);
         doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToPrint(intygsTyp, vardenhet, patient, false);
         doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToReplace(intygsTyp, vardenhet, patient);
@@ -312,7 +311,7 @@ public class ResourceLinkHelperImplTest {
         final Vardenhet vardenhet = mock(Vardenhet.class);
 
         doReturn(AccessResult.create(AccessResultCode.AUTHORIZATION_VALIDATION, "No access")).when(certificateAccessService)
-                .allowToRenew(intygsTyp, vardenhet, patient, false);
+                .allowToRenew(intygsTyp, vardenhet, patient);
         doReturn(AccessResult.create(AccessResultCode.AUTHORIZATION_VALIDATION, "No access")).when(certificateAccessService)
                 .allowToInvalidate(intygsTyp, vardenhet, patient);
         doReturn(AccessResult.create(AccessResultCode.AUTHORIZATION_VALIDATION, "No access")).when(certificateAccessService)
@@ -372,7 +371,7 @@ public class ResourceLinkHelperImplTest {
         doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToRead(anyString(), any(Vardenhet.class),
                 any(Personnummer.class));
         doReturn(AccessResult.noProblem()).when(certificateAccessService).allowToRenew(anyString(), any(Vardenhet.class),
-                any(Personnummer.class), anyBoolean());
+                any(Personnummer.class));
 
         final List<ActionLink> expectedLinks = new ArrayList<>();
         expectedLinks.add(new ActionLink(ActionLinkType.LASA_INTYG));
@@ -403,7 +402,7 @@ public class ResourceLinkHelperImplTest {
                 any(Personnummer.class));
         doReturn(AccessResult.create(AccessResultCode.AUTHORIZATION_VALIDATION, "No access")).when(certificateAccessService).allowToRenew(
                 anyString(), any(Vardenhet.class),
-                any(Personnummer.class), anyBoolean());
+                any(Personnummer.class));
 
         final List<ActionLink> expectedLinks = new ArrayList<>();
 


### PR DESCRIPTION
…llowed to complement a certificate.

Removed renew with a complement-boolean as it should always be used with false.