### PR TITLE
BUILDENV: Changed so a specific version of webdriver-manager is being…

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -17,7 +17,7 @@
         "protractor": "^5.4.2",
         "protractor-jasmine2-screenshot-reporter": "^0.5.0",
         "webcert-testtools": "file:./webcertTestTools",
-        "webdriver-manager": "^12.1.6",
+        "webdriver-manager": "12.1.6",
         "winston": "^2.2.0",
         "xml2js": "^0.4.4"
     },


### PR DESCRIPTION
… used (12.1.6) to make sure that the chrome driver doesn't change between builds/releases.