### PR TITLE
INTYGFV-12321: Rättar så att nytt utkast skapat via kopieringsoperati…

### DIFF
--- a/web/src/test/java/se/inera/intyg/webcert/web/service/utkast/AbstractBuilderTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/utkast/AbstractBuilderTest.java
@@ -18,11 +18,14 @@
  */
 package se.inera.intyg.webcert.web.service.utkast;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import se.inera.intyg.common.services.texts.IntygTextsService;
+import se.inera.intyg.common.services.texts.repo.IntygTextsRepository;
 import se.inera.intyg.common.support.model.common.internal.HoSPersonal;
 import se.inera.intyg.common.support.model.common.internal.Patient;
 import se.inera.intyg.common.support.model.common.internal.Vardenhet;
@@ -68,6 +71,9 @@ public class AbstractBuilderTest {
     @Mock
     protected WebCertUserService webcertUserService;
 
+    @Mock
+    protected IntygTextsService intygTextsService;
+
     @Spy
     protected CreateIntygsIdStrategy mockIdStrategy = new CreateIntygsIdStrategy() {
         @Override
@@ -103,6 +109,10 @@ public class AbstractBuilderTest {
     @Before
     public void expectCallToWebcertUserService() {
         when(webcertUserService.isAuthorizedForUnit(VARDGIVARE_ID, VARDENHET_ID, true)).thenReturn(true);
+    }
+    @Before
+    public void expectCallIntygTextService() {
+        when(intygTextsService.getLatestVersionForSameMajorVersion(anyString(), anyString())).thenReturn("1.0");
     }
 
     protected static Personnummer createPnr(String personId) {

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/utkast/CreateRenewalCopyUtkastBuilderImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/utkast/CreateRenewalCopyUtkastBuilderImplTest.java
@@ -86,6 +86,7 @@ public class CreateRenewalCopyUtkastBuilderImplTest extends AbstractBuilderTest 
     @Test
     public void testPopulateRenewalUtkastFromSignedIntyg() throws Exception {
 
+        when(intygTextsService.getLatestVersionForSameMajorVersion(anyString(), anyString())).thenReturn("1.2");
         IntygContentHolder ich = createIntygContentHolder();
         when(mockIntygService.fetchIntygData(INTYG_ID, INTYG_TYPE, false)).thenReturn(ich);
 
@@ -106,6 +107,7 @@ public class CreateRenewalCopyUtkastBuilderImplTest extends AbstractBuilderTest 
         assertNotNull(builderResponse.getUtkast());
         assertNotNull(builderResponse.getUtkast().getModel());
         assertEquals(INTYG_TYPE, builderResponse.getUtkast().getIntygsTyp());
+        assertEquals("1.2", builderResponse.getUtkast().getIntygTypeVersion());
         assertEquals(PATIENT_SSN, builderResponse.getUtkast().getPatientPersonnummer());
         assertEquals(PATIENT_FNAME, builderResponse.getUtkast().getPatientFornamn());
         assertEquals(PATIENT_MNAME, builderResponse.getUtkast().getPatientMellannamn());


### PR DESCRIPTION
…oner (förnya, ersätt, kopiera från annat intyg  osv) får "sin" intygstyps senaste minorversion och INTE källintygets.