### PR TITLE
BUILDENV: Ladda enbart upp liquibase arkivet, de andra används ej och…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "se.inera.intyg.plugin.common" version "2.0.3" apply false
+    id "se.inera.intyg.plugin.common" version "2.0.9" apply false
     id "org.gretty" version "2.3.1" apply false
     id "com.moowork.node" version "1.2.0" apply false
 }
@@ -103,6 +103,10 @@ allprojects {
     targetCompatibility = 1.8
 
     task createVersionPropertyFile(type: VersionPropertyFileTask)
+
+    configurations.archives.with {
+        artifacts.remove artifacts.find { !it.name.equals("webcert-liquibase-runner") }
+    }
 
     uploadArchives.repositories.mavenDeployer {
         repository(url: "https://build-inera.nordicmedtest.se/nexus/repository/releases/") {


### PR DESCRIPTION
… orsakar fel i byggpipelinen

Bumnpat intygs-pluginen till  2.0.9 (clean fix)