### PR TITLE
INTYGFV-12379: Nullcheck innan IntygInfoservice försöker beräkna låsn…

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/intyginfo/IntygInfoService.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/intyginfo/IntygInfoService.java
@@ -272,7 +272,9 @@ public class IntygInfoService {
         // Locked
         if (UtkastStatus.DRAFT_LOCKED.equals(utkast.getStatus())) {
             IntygInfoEvent locked = new IntygInfoEvent(Source.WEBCERT);
-            locked.setDate(utkast.getSkapad().plusDays(lockedAfterDay));
+            if (utkast.getSkapad() != null) {
+                locked.setDate(utkast.getSkapad().plusDays(lockedAfterDay));
+            }
             locked.setType(IntygInfoEventType.IS003);
             events.add(locked);
         }


### PR DESCRIPTION
…ingsdatum för utkast där skapad=null (=de som skapades innan kolumnen infördes)