### PR TITLE
INTYGFV-12680: Handle catched non-typed Exception in CertificateStore…

### DIFF
--- a/build-info.json
+++ b/build-info.json
@@ -2,7 +2,7 @@
   "appVersion": "6.5.0",
   "commonVersion": "3.11.0.+",
   "infraVersion": "3.11.0.+",
-  "buildArgs": "--refresh-dependencies clean build camelTest testReport -PcodeQuality -DgruntColors=false --scan s",
+  "buildArgs": "--refresh-dependencies clean build camelTest testReport -DgruntColors=false --scan s",
   "tests": [
     "restAssuredTest",
     "protractorTest"

--- a/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessor.java
+++ b/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessor.java
@@ -62,7 +62,7 @@ public class CertificateStoreProcessor {
         } catch (WebServiceException e) {
             throw new TemporaryException(e.getMessage());
         } catch (Exception e) {
-            throw new PermanentException(e.getMessage());
+            throw new TemporaryException(e);
         }
     }
 }

--- a/notification-sender/src/test/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessorTest.java
+++ b/notification-sender/src/test/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessorTest.java
@@ -135,8 +135,8 @@ public class CertificateStoreProcessorTest {
         certificateStoreProcessor.process(BODY, "fk7263", LOGICAL_ADDRESS1);
     }
 
-    @Test(expected = PermanentException.class)
-    public void testStoreCertificateThrowsPermanentOnException() throws Exception {
+    @Test(expected = TemporaryException.class)
+    public void testStoreCertificateThrowsTemporaryOnException() throws Exception {
         // Given
         doThrow(new RuntimeException()).when(moduleApi).registerCertificate(anyString(), anyString());
 


### PR DESCRIPTION
…Processor as TemporaryExceptions instead of PermanentExceptions to allow Webcert to retry storing the certificate in Intygstjansten.