### PR TITLE
INTYGFV-12800: Corrected a spelling error in the log message for TEST…

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/monitoring/MonitoringLogServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/monitoring/MonitoringLogServiceImpl.java
@@ -501,7 +501,7 @@ public class MonitoringLogServiceImpl implements MonitoringLogService {
 
         SAML_STATUS_LOGIN_FAIL("Login failed at IDP '{}' with status message '{}'"),
 
-        TEST_CERTIFICATE_ERASED("Test certificate '{}' on care unit '{}' create by '{}' was erased");
+        TEST_CERTIFICATE_ERASED("Test certificate '{}' on care unit '{}' created by '{}' was erased");
 
 
         private final String msg;


### PR DESCRIPTION
…_CERTIFICATE_ERASED