### PR TITLE
INTYGFV-12692: Removed transaction propagation REQUIRED_NEW, because …

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/message/MessageImportServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/message/MessageImportServiceImpl.java
@@ -74,13 +74,13 @@ public class MessageImportServiceImpl implements MessageImportService {
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void importMessages(String certificateId) {
         importMessages(certificateId, null);
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void importMessages(String certificateId, String excludeMessageId) {
         final var messagesToImport = findMessagesToImport(certificateId, excludeMessageId);
         if (messagesToImport.isEmpty()) {


### PR DESCRIPTION
…it is not guaranteed that the transaction is committed before calling service queries messages. Behavior differs on the h2-database compared to mysql.