### PR TITLE
INTYGFV-13464: Hiding the forward button on db when patient is deceased in Unsigned draft view

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/util/UtkastUtil.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/util/UtkastUtil.java
@@ -42,4 +42,15 @@ public final class UtkastUtil {
         return vardenhet;
     }
 
+    public static Vardenhet getCareUnit(String vardgivarId, String enhetsId) {
+        final Vardgivare vardgivare = new Vardgivare();
+        vardgivare.setVardgivarid(vardgivarId);
+
+        final Vardenhet vardenhet = new Vardenhet();
+        vardenhet.setEnhetsid(enhetsId);
+        vardenhet.setVardgivare(vardgivare);
+
+        return vardenhet;
+    }
+
 }

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiController.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiController.java
@@ -301,6 +301,8 @@ public class UtkastApiController extends AbstractApiController {
 
         listIntygEntries.stream().forEach(lie -> markTestIndicator(lie, testIndicatorStatusMap));
 
+        listIntygEntries.forEach(this::markAvliden);
+
         final Comparator<ListIntygEntry> intygComparator = getIntygComparator(filter.getOrderBy(), filter.getOrderAscending());
         intygDraftDecorator.decorateWithCertificateTypeName(listIntygEntries);
         intygDraftDecorator.decorateWithCertificateStatusName(listIntygEntries);
@@ -406,6 +408,12 @@ public class UtkastApiController extends AbstractApiController {
     private void markTestIndicator(ListIntygEntry lie, Map<Personnummer, Boolean> testIndicatorStatusMap) {
         if (testIndicatorStatusMap.get(lie.getPatientId())) {
             lie.setTestIntyg(true);
+        }
+    }
+
+    private void markAvliden(ListIntygEntry listIntygEntry) {
+        if (patientDetailsResolver.isAvliden(listIntygEntry.getPatientId())) {
+            listIntygEntry.setAvliden(true);
         }
     }
 }

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiController.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiController.java
@@ -72,6 +72,8 @@ import se.inera.intyg.webcert.web.web.controller.api.dto.ListIntygEntry;
 import se.inera.intyg.webcert.web.web.controller.api.dto.QueryIntygParameter;
 import se.inera.intyg.webcert.web.web.controller.api.dto.QueryIntygResponse;
 import se.inera.intyg.webcert.web.web.util.access.AccessResultExceptionHelper;
+import se.inera.intyg.webcert.web.web.util.resourcelinks.dto.ActionLink;
+import se.inera.intyg.webcert.web.web.util.resourcelinks.dto.ActionLinkType;
 
 /**
  * API controller for REST services concerning certificate drafts.
@@ -417,8 +419,10 @@ public class UtkastApiController extends AbstractApiController {
         String certificateType = listIntygEntry.getIntygType();
         Personnummer patientId = listIntygEntry.getPatientId();
         Vardenhet careUnit = UtkastUtil.getCareUnit(listIntygEntry.getVardgivarId(), listIntygEntry.getVardenhetId());
-        boolean forwardingAllowed = draftAccessService.allowToForwardDraft(certificateType, careUnit, patientId).isAllowed();
+        boolean isForwardingAllowed = draftAccessService.allowToForwardDraft(certificateType, careUnit, patientId).isAllowed();
 
-        listIntygEntry.setForwardingAllowed(forwardingAllowed);
+        if (isForwardingAllowed) {
+            listIntygEntry.addLink(new ActionLink(ActionLinkType.VIDAREBEFORDRA_UTKAST));
+        }
     }
 }

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/dto/ListIntygEntry.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/dto/ListIntygEntry.java
@@ -70,8 +70,6 @@ public class ListIntygEntry {
 
     private boolean isTestIntyg = false;
 
-    private boolean forwardingAllowed;
-
 
     public String getIntygId() {
         return intygId;
@@ -231,14 +229,6 @@ public class ListIntygEntry {
 
     public void setTestIntyg(boolean isTestIntyg) {
         this.isTestIntyg = isTestIntyg;
-    }
-
-    public boolean isForwardingAllowed() {
-        return forwardingAllowed;
-    }
-
-    public void setForwardingAllowed(boolean forwardAllowed) {
-        this.forwardingAllowed = forwardAllowed;
     }
 
     @Override

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/dto/ListIntygEntry.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/api/dto/ListIntygEntry.java
@@ -70,6 +70,8 @@ public class ListIntygEntry {
 
     private boolean isTestIntyg = false;
 
+    private boolean forwardingAllowed;
+
 
     public String getIntygId() {
         return intygId;
@@ -229,6 +231,14 @@ public class ListIntygEntry {
 
     public void setTestIntyg(boolean isTestIntyg) {
         this.isTestIntyg = isTestIntyg;
+    }
+
+    public boolean isForwardingAllowed() {
+        return forwardingAllowed;
+    }
+
+    public void setForwardingAllowed(boolean forwardAllowed) {
+        this.forwardingAllowed = forwardAllowed;
     }
 
     @Override

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/util/resourcelinks/dto/ActionLinkType.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/util/resourcelinks/dto/ActionLinkType.java
@@ -56,6 +56,11 @@ public enum ActionLinkType {
     KOPIERA_UTKAST,
 
     /**
+     * Forward draft.
+     */
+    VIDAREBEFORDRA_UTKAST,
+
+    /**
      * Renew certificate.
      */
     FORNYA_INTYG,

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
@@ -103,7 +103,7 @@
       <div class="col-xs-12">
         <button type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg)" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg)"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg) && !(intyg.avliden && intyg.intygType == 'db')"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                  popover-placement="top" popover-popup-delay="300"
                 popover-append-to-body="true">

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
@@ -37,7 +37,7 @@
       <td class="unbreakable">
         <button ng-attr-id="vidarebefordraBtn-{{intyg.intygId}}" type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg);openMaildialogTooltip=false;" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg)"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg) && !(intyg.avliden && intyg.intygType == 'db')"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                 popover-is-open="openMaildialogTooltip"
                  popover-placement="top" popover-popup-delay="300"

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
@@ -37,7 +37,7 @@
       <td class="unbreakable">
         <button ng-attr-id="vidarebefordraBtn-{{intyg.intygId}}" type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg);openMaildialogTooltip=false;" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && intyg.forwardingAllowed"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg.links)"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                 popover-is-open="openMaildialogTooltip"
                  popover-placement="top" popover-popup-delay="300"
@@ -103,7 +103,7 @@
       <div class="col-xs-12">
         <button type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg)" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && intyg.forwardingAllowed"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg.links)"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                  popover-placement="top" popover-popup-delay="300"
                 popover-append-to-body="true">

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html
@@ -37,7 +37,7 @@
       <td class="unbreakable">
         <button ng-attr-id="vidarebefordraBtn-{{intyg.intygId}}" type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg);openMaildialogTooltip=false;" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg) && !(intyg.avliden && intyg.intygType == 'db')"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && intyg.forwardingAllowed"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                 popover-is-open="openMaildialogTooltip"
                  popover-placement="top" popover-popup-delay="300"
@@ -103,7 +103,7 @@
       <div class="col-xs-12">
         <button type="button" class="btn btn-primary"
                 ng-click="openMailDialog(intyg)" intygstyp="{{::intyg.intygType}}"
-                ng-if="intyg.status != 'DRAFT_LOCKED' && showVidarebefordra(intyg) && !(intyg.avliden && intyg.intygType == 'db')"
+                ng-if="intyg.status != 'DRAFT_LOCKED' && intyg.forwardingAllowed"
                 uib-popover-html="'Skapar ett e-postmeddelande i din e-postklient med en direktlänk till utkastet.'"
                  popover-placement="top" popover-popup-delay="300"
                 popover-append-to-body="true">

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.js
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.js
@@ -18,8 +18,8 @@
  */
 
 angular.module('webcert').directive('wcUtkastList',
-    ['common.UtkastNotifyService', 'common.moduleService', 'common.IntygHelper', 'common.authorityService',
-      function(utkastNotifyService, moduleService, IntygHelper, authorityService) {
+    ['common.UtkastNotifyService', 'common.moduleService', 'common.IntygHelper', 'common.authorityService', 'common.ResourceLinkService',
+      function(utkastNotifyService, moduleService, IntygHelper, authorityService, ResourceLinkService) {
         'use strict';
 
         return {
@@ -34,12 +34,8 @@ angular.module('webcert').directive('wcUtkastList',
           templateUrl: '/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html',
           controller: function($scope) {
 
-            $scope.showVidarebefordra = function(intyg) {
-              var options = {
-                authority: 'VIDAREBEFORDRA_UTKAST',
-                intygstyp: intyg.intygType
-              };
-              return authorityService.isAuthorityActive(options);
+            $scope.showVidarebefordras = function(links) {
+              return ResourceLinkService.isLinkTypeExists(links, 'VIDAREBEFORDRA_UTKAST');
             };
 
             $scope.getTypeName = function(intygsType) {

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.js
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.js
@@ -34,7 +34,7 @@ angular.module('webcert').directive('wcUtkastList',
           templateUrl: '/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.html',
           controller: function($scope) {
 
-            $scope.showVidarebefordras = function(links) {
+            $scope.showVidarebefordra = function(links) {
               return ResourceLinkService.isLinkTypeExists(links, 'VIDAREBEFORDRA_UTKAST');
             };
 

--- a/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.spec.js
+++ b/web/src/main/webapp/app/views/ejSigneradeUtkast/wcUtkastList/wcUtkastList.directive.spec.js
@@ -53,6 +53,12 @@ describe('wcUtkastListSpec', function() {
           jasmine.createSpyObj('common.IntygHelper', ['goToDraft']);
       $provide.value('common.IntygHelper', IntygHelper);
 
+      $provide.value('common.ResourceLinkService', {
+        isLinkTypeExists: function(links, type) {
+          return true;
+        }
+      });
+
       _$stateProvider_.state('fk7263.utkast', {
         url: '/fk7263/edit/:certificateId'
       });

--- a/web/src/test/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiControllerTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/web/controller/api/UtkastApiControllerTest.java
@@ -74,6 +74,7 @@ import se.inera.intyg.webcert.persistence.utkast.model.Utkast;
 import se.inera.intyg.webcert.persistence.utkast.model.VardpersonReferens;
 import se.inera.intyg.webcert.web.converter.util.IntygDraftDecorator;
 import se.inera.intyg.webcert.web.service.access.AccessResult;
+import se.inera.intyg.webcert.web.service.access.AccessResultCode;
 import se.inera.intyg.webcert.web.service.access.DraftAccessService;
 import se.inera.intyg.webcert.web.service.log.LogService;
 import se.inera.intyg.webcert.web.service.patient.PatientDetailsResolver;
@@ -283,6 +284,8 @@ public class UtkastApiControllerTest {
         when(utkastService.filterIntyg(any()))
             .thenReturn(Arrays.asList(buildUtkast(PATIENT_PERSONNUMMER), buildUtkast(PATIENT_PERSONNUMMER)));
 
+        when(draftAccessService.allowToForwardDraft(any(), any(), any())).thenReturn(AccessResult.noProblem());
+
         final Response response = utkastController.filterDraftsForUnit(buildQueryIntygParameter());
         final QueryIntygResponse queryIntygResponse = response.readEntity(QueryIntygResponse.class);
         assertEquals(2, queryIntygResponse.getTotalCount());
@@ -310,6 +313,7 @@ public class UtkastApiControllerTest {
         nameByHsaid.put("lakareid2", "c");
         nameByHsaid.put("lakareid3", "a");
         Mockito.doReturn(nameByHsaid).when(utkastControllerSpy).getNamesByHsaIds(any());
+        when(draftAccessService.allowToForwardDraft(any(), any(), any())).thenReturn(AccessResult.noProblem());
 
         //When
         final Response response = utkastControllerSpy.filterDraftsForUnit(filterParameters);
@@ -336,6 +340,8 @@ public class UtkastApiControllerTest {
         final QueryIntygParameter filterParameters = buildQueryIntygParameter();
         filterParameters.setOrderAscending(false);
         filterParameters.setOrderBy("patientPersonnummer");
+
+        when(draftAccessService.allowToForwardDraft(any(), any(), any())).thenReturn(AccessResult.noProblem());
 
         //When
         final Response response = utkastController.filterDraftsForUnit(filterParameters);
@@ -367,6 +373,8 @@ public class UtkastApiControllerTest {
                 buildUtkast(PATIENT_PERSONNUMMER, new VardpersonReferens(hsaIdNotFound, nameNotFound)),
                 utkast2));
 
+        when(draftAccessService.allowToForwardDraft(any(), any(), any())).thenReturn(AccessResult.noProblem());
+
         final Response response = utkastController.filterDraftsForUnit(buildQueryIntygParameter());
         final QueryIntygResponse queryIntygResponse = response.readEntity(QueryIntygResponse.class);
         assertEquals(2, queryIntygResponse.getTotalCount());
@@ -395,6 +403,7 @@ public class UtkastApiControllerTest {
 
         when(utkastService.filterIntyg(any()))
             .thenReturn(Arrays.asList(buildUtkast(PATIENT_PERSONNUMMER), buildUtkast(PATIENT_PERSONNUMMER_PU_SEKRETESS)));
+        when(draftAccessService.allowToForwardDraft(any(), any(), any())).thenReturn(AccessResult.noProblem());
 
         final Response response = utkastController.filterDraftsForUnit(buildQueryIntygParameter());
         final QueryIntygResponse queryIntygResponse = response.readEntity(QueryIntygResponse.class);


### PR DESCRIPTION
Test found that the forward button was erroneously displayed on db for deceased patients in the Unsigned draft view. These changes hide the forward button when the patient is deceased.  