### PR TITLE
INTYGFV-12452: Harmonization of logback file usage and structure

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile "se.inera.intyg.infra:log-messages:${infraVersion}"
+    compile "se.inera.intyg.infra:monitoring:${infraVersion}"
     compile "se.inera.intyg.infra:security-siths:${infraVersion}"
     compile "se.inera.intyg.common:fk7263:${commonVersion}"
     compile "se.inera.intyg.common:ts-parent:${commonVersion}"

--- a/devops/openshift/test/config/logback-ocp.xml
+++ b/devops/openshift/test/config/logback-ocp.xml
@@ -24,29 +24,31 @@
 
     <include resource="logback-ocp-base.xml"/>
 
-    <appender name="HSA" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
-            <marker>HSA</marker>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>${TIMESTAMP} [hsa,${SESSION},${TRACE}] ${LINE}</pattern>
-        </encoder>
-    </appender>
+    <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="off" />
 
+    <logger name="se.inera.intyg.common" level="info" />
+    <logger name="se.inera.intyg.infra.integration" level="info" />
+    <logger name="se.inera.intyg.intygstyper" level="info" />
+    <logger name="se.inera.intyg.webcert.web.auth" level="info" />
+    <logger name="se.inera.intyg.webcert" level="info" />
+    <logger name="se.inera.webcert.notifications" level="info" />
+
+    <logger name="org.apache.cxf" level="off" />
+
+    <logger name="com.fasterxml.jackson" level="off" />
+
+    <logger name="org.springframework.transaction" level="info" />
 
     <!-- Log service for monitoring and audit information -->
     <logger name="se.inera.intyg.webcert.web.service.monitoring.MonitoringLogService" level="info">
         <appender-ref ref="MONITORING" />
     </logger>
 
-    <logger name="liquibase" level="info" />
-    <logger name="org.springframework.beans.factory.xml" level="debug" />
+    <!-- Log service for logging JavaScript exceptions from GUI, set to info or off -->
+    <logger name="se.inera.intyg.webcert.web.web.controller.api.JsLogApiController" level="off" />
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="HSA"/>
     </root>
 
 </configuration>

--- a/stubs/fk-stub/src/main/java/se/inera/intyg/webcert/fkstub/validation/PatientValidator.java
+++ b/stubs/fk-stub/src/main/java/se/inera/intyg/webcert/fkstub/validation/PatientValidator.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import se.inera.ifv.insuranceprocess.healthreporting.v2.PatientType;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 
 public final class PatientValidator {
 

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/monitoring/MonitoringLogServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/monitoring/MonitoringLogServiceImpl.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import se.inera.intyg.common.support.common.enumerations.RelationKod;
-import se.inera.intyg.common.util.logging.LogMarkers;
+import se.inera.intyg.infra.monitoring.logging.LogMarkers;
 import se.inera.intyg.schemas.contract.Personnummer;
 import se.inera.intyg.webcert.persistence.arende.model.ArendeAmne;
 import se.inera.intyg.webcert.persistence.fragasvar.model.Amne;

--- a/web/src/main/resources/logback-dev.xml
+++ b/web/src/main/resources/logback-dev.xml
@@ -24,7 +24,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <withJansi>true</withJansi>
-    <filter class="se.inera.intyg.common.util.logging.MarkerFilter">
+    <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
       <markers>Monitoring</markers>
       <onMatch>DENY</onMatch>
       <onMismatch>ACCEPT</onMismatch>
@@ -38,7 +38,7 @@
 
   <appender name="MONITORING" class="ch.qos.logback.core.ConsoleAppender">
     <withJansi>true</withJansi>
-    <filter class="se.inera.intyg.common.util.logging.MarkerFilter">
+    <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
       <markers>Monitoring</markers>
       <onMatch>ACCEPT</onMatch>
       <onMismatch>DENY</onMismatch>

--- a/web/src/main/resources/logback-dev.xml
+++ b/web/src/main/resources/logback-dev.xml
@@ -24,7 +24,6 @@
 
   <include resource="logback-dev-base.xml" />
 
-
   <logger name="com.fasterxml.jackson" level="off" />
 
   <logger name="liquibase" level="info" />
@@ -51,7 +50,6 @@
 
   <!-- Log service for logging JavaScript exceptions from GUI, set to info or off -->
   <logger name="se.inera.intyg.webcert.web.web.controller.api.JsLogApiController" level="off" />
-
 
   <root level="WARN">
     <appender-ref ref="CONSOLE"/>

--- a/web/src/main/resources/logback-dev.xml
+++ b/web/src/main/resources/logback-dev.xml
@@ -18,81 +18,46 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<configuration scan="true" scanPeriod="30 seconds">
+<configuration>
 
-  <jmxConfigurator />
+  <property name="APP_NAME" value="${APP_NAME:-webcert}"/>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <withJansi>true</withJansi>
-    <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
-      <markers>Monitoring</markers>
-      <onMatch>DENY</onMatch>
-      <onMismatch>ACCEPT</onMismatch>
-    </filter>
-    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-      <layout class="se.inera.intyg.webcert.web.logging.PatternLayoutWithUserContext">
-        <param name="Pattern" value="%date{ISO8601} [%thread] %highlight(%-5level) %logger{10} [%user %session] - %msg%n" />
-      </layout>
-    </encoder>
-  </appender>
+  <include resource="logback-dev-base.xml" />
 
-  <appender name="MONITORING" class="ch.qos.logback.core.ConsoleAppender">
-    <withJansi>true</withJansi>
-    <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
-      <markers>Monitoring</markers>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-      <layout class="se.inera.intyg.webcert.web.logging.PatternLayoutWithUserContext">
-        <param name="Pattern" value="%date{ISO8601} [%thread] %highlight(%-5level) %boldGreen(%logger{10}) [%user %session] - %msg%n" />
-      </layout>
-    </encoder>
-  </appender>
-
-  <logger name="org.springframework" level="error" />
-
-  <logger name="org.hibernate" level="info" />
-  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="on" />
-
-  <logger name="org.apache.cxf.services" level="error" />
-
-  <logger name="se.inera.intyg.webcert.web" level="debug" />
-
-  <logger name="se.inera.intyg.webcert.web.auth" level="info" />
-
-  <logger name="se.inera.intyg.webcert" level="info" />
-
-  <logger name="se.inera.intyg.common" level="info" />
-
-  <logger name="org.apache.camel" level="error" />
-
-  <logger name="org.apache.cxf" level="off" />
 
   <logger name="com.fasterxml.jackson" level="off" />
 
+  <logger name="liquibase" level="info" />
+
+  <logger name="org.apache.cxf" level="off" />
+  <logger name="org.apache.cxf.services" level="error" />
+  <logger name="org.apache.camel" level="error" />
+
+  <logger name="org.hibernate" level="info" />
+  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="off" />
+
+  <logger name="org.springframework" level="error" />
+  <logger name="org.springframework.beans.factory.xml" level="debug" />
+  <logger name="org.springframework.security.saml.log.SAMLDefaultLogger" level="info" />
   <logger name="org.springframework.transaction" level="info" />
 
-  <logger name="se.inera.webcert.notifications" level="info" />
-
+  <logger name="se.inera.intyg.common" level="info" />
   <logger name="se.inera.intyg.infra" level="info" />
-
-  <!-- Logger from saml info -->
-  <logger name="org.springframework.security.saml.log.SAMLDefaultLogger" level="info" />
-
-  <!-- Log service for monitoring and audit information -->
+  <logger name="se.inera.intyg.webcert" level="info" />
+  <logger name="se.inera.intyg.webcert.web" level="debug" />
+  <logger name="se.inera.intyg.webcert.web.auth" level="info" />
   <logger name="se.inera.intyg.webcert.web.service.monitoring.MonitoringLogService" level="info" />
+  <logger name="se.inera.webcert.notifications" level="info" />
 
   <!-- Log service for logging JavaScript exceptions from GUI, set to info or off -->
   <logger name="se.inera.intyg.webcert.web.web.controller.api.JsLogApiController" level="off" />
 
-  <logger name="liquibase" level="info" />
 
-  <logger name="org.springframework.beans.factory.xml" level="debug" />
-
-  <root>
-    <level value="error" />
-    <appender-ref ref="STDOUT" />
-    <appender-ref ref="MONITORING" />
+  <root level="WARN">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="MONITORING"/>
+    <appender-ref ref="VALIDATION"/>
   </root>
+
 </configuration>
+

--- a/web/src/main/resources/logback-ocp.xml
+++ b/web/src/main/resources/logback-ocp.xml
@@ -24,27 +24,31 @@
 
     <include resource="logback-ocp-base.xml"/>
 
-    <appender name="HSA" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="se.inera.intyg.infra.monitoring.logging.MarkerFilter">
-            <marker>HSA</marker>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>${TIMESTAMP} [hsa,${SESSION},${TRACE}] ${LINE}</pattern>
-        </encoder>
-    </appender>
+    <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="off" />
 
+    <logger name="se.inera.intyg.common" level="info" />
+    <logger name="se.inera.intyg.infra.integration" level="info" />
+    <logger name="se.inera.intyg.intygstyper" level="info" />
+    <logger name="se.inera.intyg.webcert.web.auth" level="info" />
+    <logger name="se.inera.intyg.webcert" level="info" />
+    <logger name="se.inera.webcert.notifications" level="info" />
+
+    <logger name="org.apache.cxf" level="off" />
+
+    <logger name="com.fasterxml.jackson" level="off" />
+
+    <logger name="org.springframework.transaction" level="info" />
 
     <!-- Log service for monitoring and audit information -->
-    <logger name="se.inera.intyg.webcert.web.service.monitoring.MonitoringLogService" level="INFO">
+    <logger name="se.inera.intyg.webcert.web.service.monitoring.MonitoringLogService" level="info">
         <appender-ref ref="MONITORING" />
     </logger>
 
+    <!-- Log service for logging JavaScript exceptions from GUI, set to info or off -->
+    <logger name="se.inera.intyg.webcert.web.web.controller.api.JsLogApiController" level="off" />
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="HSA"/>
     </root>
 
 </configuration>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -36,7 +36,7 @@
 
     <!-- Listener for external logback configuration file -->
     <listener>
-        <listener-class>se.inera.intyg.common.util.logging.LogbackConfiguratorContextListener</listener-class>
+        <listener-class>se.inera.intyg.infra.monitoring.logging.LogbackConfiguratorContextListener</listener-class>
     </listener>
 
     <!-- Start spring context -->


### PR DESCRIPTION
Work on this jira was aimed at harmonization of logback usage across all applications and included actions in infra, common, intygsadmin, intygstjanst, logsender, minaintyg, privatlakarportal, rehabstod, statistik and webcert. Briefly, logging functionality was collected in infra/monitoring, a logback-dev file was introduced for use in dev-environment and logback-ocp files (in web/resources as a backup and in devops/openshift/test) was set to produce logging identical to current prod-logging.  A summary of all actions can be found in PRs in common and infra.