### PR TITLE
INTYGFV-14030: Remove redundant Pdl-logging when copy a locked draft.

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/moduleapi/UtkastModuleApiController.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/moduleapi/UtkastModuleApiController.java
@@ -336,7 +336,7 @@ public class UtkastModuleApiController extends AbstractApiController {
         LOG.debug("Attempting to create a new certificate from certificate with type {} and id '{}'",
             intygsTyp, orgIntygsId);
 
-        Utkast utkast = utkastService.getDraft(orgIntygsId, intygsTyp);
+        Utkast utkast = utkastService.getDraft(orgIntygsId, intygsTyp, false);
 
         // Do authorization check
         lockedDraftAccessServiceHelper.validateAccessToCopy(utkast);

--- a/web/src/test/java/se/inera/intyg/webcert/web/web/controller/integrationtest/facade/IntegrationTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/web/controller/integrationtest/facade/IntegrationTest.java
@@ -38,8 +38,8 @@ public class IntegrationTest {
     public static String BETA_VARDCENTRAL = "TSTNMT2321000156-BEVC";
     public static String BETA_LAKARMOTTAGNING = "TSTNMT2321000156-BELM";
 
-    public static Patient ATHENA_ANDERSSON = createPatient("191212121212", "Athena", "Andersson");
-    public static Patient ALEXA_VALFRIDSSON = createPatient("201212121212", "Alexa", "Valfridsson");
+    public static Patient ATHENA_ANDERSSON = createPatient("194011306125", "Athena", "Andersson");
+    public static Patient ALEXA_VALFRIDSSON = createPatient("194110299221", "Alexa", "Valfridsson");
 
     private static Patient createPatient(String id, String firstName, String lastName) {
         final var personId = new PersonId();

--- a/web/src/test/java/se/inera/intyg/webcert/web/web/controller/moduleapi/UtkastModuleApiControllerTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/web/controller/moduleapi/UtkastModuleApiControllerTest.java
@@ -391,7 +391,7 @@ public class UtkastModuleApiControllerTest {
 
         Utkast utkast = new Utkast();
         utkast.setPatientPersonnummer(Personnummer.createPersonnummer("19121212-1212").get());
-        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp))).thenReturn(utkast);
+        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp), eq(Boolean.FALSE))).thenReturn(utkast);
 
         ArgumentCaptor<CreateUtkastFromTemplateRequest> captor = ArgumentCaptor.forClass(CreateUtkastFromTemplateRequest.class);
         when(copyUtkastService.createUtkastCopy(captor.capture()))
@@ -410,7 +410,7 @@ public class UtkastModuleApiControllerTest {
         String intygsId = "intygId";
         String intygsTyp = "fk7263";
 
-        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp))).thenReturn(mock(Utkast.class));
+        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp), eq(Boolean.FALSE))).thenReturn(mock(Utkast.class));
 
         doThrow(
             new WebCertServiceException(WebCertServiceErrorCodeEnum.AUTHORIZATION_PROBLEM_SEKRETESSMARKERING, "Some error message")
@@ -437,7 +437,7 @@ public class UtkastModuleApiControllerTest {
 
         Utkast utkast = new Utkast();
         utkast.setPatientPersonnummer(createPnr("19121212-1212"));
-        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp))).thenReturn(utkast);
+        when(utkastService.getDraft(eq(intygsId), eq(intygsTyp), eq(Boolean.FALSE))).thenReturn(utkast);
 
         ArgumentCaptor<CreateUtkastFromTemplateRequest> captor = ArgumentCaptor.forClass(CreateUtkastFromTemplateRequest.class);
         when(copyUtkastService.createUtkastCopy(captor.capture()))


### PR DESCRIPTION
I've changed a couple of test patient ids at the same time for our integrationstests.