### PR TITLE
INTYGFV-14077: Updated datatype in subset of columns in FMB tables to…

### DIFF
--- a/persistence/src/main/resources/changelog/changelog.xml
+++ b/persistence/src/main/resources/changelog/changelog.xml
@@ -1405,4 +1405,11 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="69" author="mh">
+    <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="FORSAKRINGSMEDICINSK_INFORMATION" newDataType="text"/>
+    <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="SYMPTOM_PROGNOS_BEHANDLING" newDataType="text"/>
+    <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="INFORMATION_OM_REHABILITERING" newDataType="text"/>
+    <modifyDataType tableName="FMB_BESKRIVNING" columnName="BESKRIVNING" newDataType="text"/>
+    <modifyDataType tableName="FMB_TYPFALL" columnName="TYPFALLSMENING" newDataType="text"/>
+  </changeSet>
 </databaseChangeLog>

--- a/persistence/src/main/resources/changelog/changelog.xml
+++ b/persistence/src/main/resources/changelog/changelog.xml
@@ -1406,10 +1406,10 @@
   </changeSet>
 
   <changeSet id="69" author="mh">
-    <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="FORSAKRINGSMEDICINSK_INFORMATION" newDataType="text"/>
-    <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="SYMPTOM_PROGNOS_BEHANDLING" newDataType="text"/>
+    <addNotNullConstraint tableName="FMB_DIAGNOS_INFORMATION" columnName="FORSAKRINGSMEDICINSK_INFORMATION" columnDataType="text"/>
+    <addNotNullConstraint tableName="FMB_DIAGNOS_INFORMATION" columnName="SYMPTOM_PROGNOS_BEHANDLING" columnDataType="text"/>
+    <addNotNullConstraint tableName="FMB_BESKRIVNING" columnName="BESKRIVNING" columnDataType="text"/>
+    <addNotNullConstraint tableName="FMB_TYPFALL" columnName="TYPFALLSMENING" columnDataType="text"/>
     <modifyDataType tableName="FMB_DIAGNOS_INFORMATION" columnName="INFORMATION_OM_REHABILITERING" newDataType="text"/>
-    <modifyDataType tableName="FMB_BESKRIVNING" columnName="BESKRIVNING" newDataType="text"/>
-    <modifyDataType tableName="FMB_TYPFALL" columnName="TYPFALLSMENING" newDataType="text"/>
   </changeSet>
 </databaseChangeLog>

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -179,7 +179,7 @@ privatepractitioner.internalapi.validate.url=${privatepractitioner.internalapi.b
 # FMB Configuration
 #
 ################################################
-fmb.dataupdate.cron = 0 0 2 * * *
+fmb.dataupdate.cron = 0 45 1 * * *
 
 #####################
 # ICF Configuration #


### PR DESCRIPTION
… allow longer texts. Changed time for nightly fmb update.

The previously used time for fmb updates (02:00) coincided, in prod, with the time for the lock-job. Since we have several pods in prod, this led to the fmb update being started in one pod while also being queued after the lock-job in another. When the lock job was done (after 35-70 minutes), the first pod running the fmb update had since long finished, which led to the queued fmb update being run too. This is why the fmb update was run, (with few exceptions), twice each night, Could either be solved by setting a scheduler lock (for the duration of the lock job) or by separating the the start times of the two jobs. Decided to go for the separation, thus setting the start time for fmb update to 01:45.

Also adding sql script for modification of column datatypes to the jira.