### PR TITLE
INTYGFV-14126: Filter out question events that are not needed for the…

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImpl.java
@@ -62,7 +62,7 @@ public class GetCertificateEventsFacadeServiceImpl implements GetCertificateEven
         EventCode.KFSIGN
     );
 
-    private final List<CertificateEventTypeDTO> duplicatesToFilterOut = Arrays.asList(
+    private final List<CertificateEventTypeDTO> duplicatesToFilterOut = List.of(
         CertificateEventTypeDTO.REQUEST_FOR_COMPLEMENT
     );
 
@@ -102,8 +102,7 @@ public class GetCertificateEventsFacadeServiceImpl implements GetCertificateEven
     private CertificateEventDTO[] sortAndReturnArray(List<CertificateEventDTO> events) {
         return events.stream()
             .sorted(Comparator.comparing(CertificateEventDTO::getTimestamp))
-            .collect(Collectors.toList())
-            .toArray(new CertificateEventDTO[0]);
+            .toArray(CertificateEventDTO[]::new);
     }
 
     private void addEventsBasedOnChildRelations(List<CertificateEventDTO> events, FrontendRelations childRelations, String certificateId) {
@@ -171,7 +170,7 @@ public class GetCertificateEventsFacadeServiceImpl implements GetCertificateEven
     }
 
     private List<CertificateEventDTO> getCertificateEvents(List<CertificateEvent> events) {
-        final List<CertificateEventDTO> listThatCanBeDuplicate = new ArrayList();
+        final List<CertificateEventDTO> listThatCanBeDuplicate = new ArrayList<>();
         return events.stream()
             .filter(this::shouldBeIncluded)
             .map(this::convertCertificateEvent)
@@ -242,8 +241,7 @@ public class GetCertificateEventsFacadeServiceImpl implements GetCertificateEven
     }
 
     private void decorateCertificateEventsWithParentInfo(List<CertificateEventDTO> events, WebcertCertificateRelation parentRelation) {
-        events.stream()
-            .forEach(certificateEventDTO -> decorateCertificateEventWithParentInfo(certificateEventDTO, parentRelation));
+        events.forEach(certificateEventDTO -> decorateCertificateEventWithParentInfo(certificateEventDTO, parentRelation));
     }
 
     private void decorateCertificateEventWithParentInfo(CertificateEventDTO event, WebcertCertificateRelation parentRelation) {

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImpl.java
@@ -58,7 +58,8 @@ public class GetCertificateEventsFacadeServiceImpl implements GetCertificateEven
         EventCode.HANFRFV,
         EventCode.HANFRFM,
         EventCode.NYSVFM,
-        EventCode.PAMINNELSE
+        EventCode.PAMINNELSE,
+        EventCode.KFSIGN
     );
 
     private final List<CertificateEventTypeDTO> duplicatesToFilterOut = Arrays.asList(

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/question/impl/GetQuestionsFacadeServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/question/impl/GetQuestionsFacadeServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import se.inera.intyg.common.support.facade.model.CertificateRelationType;
+import se.inera.intyg.common.support.facade.model.CertificateStatus;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateRelation;
 import se.inera.intyg.common.support.facade.model.question.Complement;
 import se.inera.intyg.common.support.facade.model.question.Question;
@@ -121,7 +122,8 @@ public class GetQuestionsFacadeServiceImpl implements GetQuestionsFacadeService 
         }
 
         return Stream.of(childrenRelations)
-            .filter(childRelation -> childRelation.getType() == CertificateRelationType.COMPLEMENTED)
+            .filter(childRelation -> childRelation.getType() == CertificateRelationType.COMPLEMENTED
+                && childRelation.getStatus() != CertificateStatus.REVOKED)
             .collect(Collectors.toList());
     }
 
@@ -181,6 +183,7 @@ public class GetQuestionsFacadeServiceImpl implements GetQuestionsFacadeService 
 
     private Question convertQuestion(Arende question, Complement[] complements, CertificateRelation answeredByCertificate,
         ArendeDraft answerDraft, Arende answer, List<Arende> reminders) {
+
         if (answer != null) {
             return questionConverter.convert(question, complements, answeredByCertificate, answer, reminders);
         }

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/question/util/QuestionConverterImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/question/util/QuestionConverterImpl.java
@@ -33,6 +33,7 @@ import se.inera.intyg.common.support.facade.model.question.Complement;
 import se.inera.intyg.common.support.facade.model.question.Question;
 import se.inera.intyg.common.support.facade.model.question.Reminder;
 import se.inera.intyg.webcert.persistence.arende.model.Arende;
+import se.inera.intyg.webcert.persistence.arende.model.ArendeAmne;
 import se.inera.intyg.webcert.persistence.arende.model.ArendeDraft;
 import se.inera.intyg.webcert.persistence.model.Status;
 
@@ -55,7 +56,7 @@ public class QuestionConverterImpl implements QuestionConverter {
 
     @Override
     public Question convert(Arende arende, Complement[] complements, CertificateRelation answeredByCertificate) {
-        return startConvert(arende, complements).build();
+        return startConvert(arende, complements, answeredByCertificate, Collections.emptyList()).build();
     }
 
     @Override
@@ -127,7 +128,7 @@ public class QuestionConverterImpl implements QuestionConverter {
             .lastUpdate(arende.getSenasteHandelse())
             .reminders(remindersToAdd)
             .complements(complements)
-            .answeredByCertificate(answeredByCertificate)
+            .answeredByCertificate(arende.getAmne() == ArendeAmne.KOMPLT ? answeredByCertificate : null)
             .lastDateToReply(
                 getLastDateToReply(arende, reminders)
             );

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImplTest.java
@@ -157,7 +157,8 @@ class GetCertificateEventsFacadeServiceImplTest {
                 EventCode.HANFRFV,
                 EventCode.HANFRFM,
                 EventCode.NYSVFM,
-                EventCode.PAMINNELSE
+                EventCode.PAMINNELSE,
+                EventCode.KFSIGN
             );
         }
 

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateEventsFacadeServiceImplTest.java
@@ -142,32 +142,49 @@ class GetCertificateEventsFacadeServiceImplTest {
         );
     }
 
-    @Test
-    /**
-     * EventCode.RELINTYGMAKULE is not relevant for the user and will be filtered out.
-     */
-    void shallExcludeRelIntygMakuleEvent() {
-        certificateEvent.setEventCode(EventCode.RELINTYGMAKULE);
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class EventTypesToFilterOut {
 
-        final var actualEvents = getCertificateEventsFacadeService.getCertificateEvents(CERTIFICATE_ID);
+        /**
+         * Event types that should be filtered out because they are currently not relevant for the user
+         */
+        Stream<EventCode> eventTypesToFilterOut() {
+            return Stream.of(
+                EventCode.RELINTYGMAKULE,
+                EventCode.NYFRFM,
+                EventCode.NYFRFV,
+                EventCode.HANFRFV,
+                EventCode.HANFRFM,
+                EventCode.NYSVFM,
+                EventCode.PAMINNELSE
+            );
+        }
 
-        assertEquals(0, actualEvents.length);
+        @ParameterizedTest
+        @MethodSource("eventTypesToFilterOut")
+        void shallFilterOutType(EventCode eventCode) {
+            certificateEvent.setEventCode(eventCode);
+
+            final var actualEvents = getCertificateEventsFacadeService.getCertificateEvents(CERTIFICATE_ID);
+
+            assertEquals(0, actualEvents.length);
+        }
+
+        @Test
+        void shallfilterOutDuplicateComplementRequests() {
+            certificateEvent.setEventCode(EventCode.KOMPLBEGARAN);
+            certificateEvents.add(certificateEvent);
+
+            final var actualEvents = getCertificateEventsFacadeService.getCertificateEvents(CERTIFICATE_ID);
+
+            assertEquals(1, actualEvents.length);
+        }
     }
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class EventTypes {
-
-        void setup() {
-            final var parentRelation = new WebcertCertificateRelation(
-                "ParentCertificateId",
-                RelationKod.ERSATT,
-                LocalDateTime.now(),
-                UtkastStatus.SIGNED,
-                false);
-
-            relations.setParent(parentRelation);
-        }
 
         Stream<Arguments> eventTypes() {
             return Stream.of(
@@ -179,12 +196,6 @@ class GetCertificateEventsFacadeServiceImplTest {
                 Arguments.of(EventCode.ERSATTER, CertificateEventTypeDTO.REPLACES),
                 Arguments.of(EventCode.FORLANGER, CertificateEventTypeDTO.EXTENDED),
                 Arguments.of(EventCode.KOPIERATFRAN, CertificateEventTypeDTO.COPIED_FROM),
-                Arguments.of(EventCode.NYFRFM, CertificateEventTypeDTO.INCOMING_MESSAGE),
-                Arguments.of(EventCode.NYFRFV, CertificateEventTypeDTO.OUTGOING_MESSAGE),
-                Arguments.of(EventCode.NYSVFM, CertificateEventTypeDTO.INCOMING_ANSWER),
-                Arguments.of(EventCode.HANFRFM, CertificateEventTypeDTO.INCOMING_MESSAGE_HANDLED),
-                Arguments.of(EventCode.HANFRFV, CertificateEventTypeDTO.OUTGOING_MESSAGE_HANDLED),
-                Arguments.of(EventCode.PAMINNELSE, CertificateEventTypeDTO.INCOMING_MESSAGE_REMINDER),
                 Arguments.of(EventCode.KOMPLBEGARAN, CertificateEventTypeDTO.REQUEST_FOR_COMPLEMENT),
                 Arguments.of(EventCode.KOMPLETTERAR, CertificateEventTypeDTO.COMPLEMENTS),
                 Arguments.of(EventCode.SKAPATFRAN, CertificateEventTypeDTO.CREATED_FROM)
@@ -201,12 +212,6 @@ class GetCertificateEventsFacadeServiceImplTest {
                 EventCode.SIGNAT,
                 EventCode.SKICKAT,
                 EventCode.MAKULERAT,
-                EventCode.NYFRFM,
-                EventCode.NYFRFV,
-                EventCode.HANFRFV,
-                EventCode.HANFRFM,
-                EventCode.NYSVFM,
-                EventCode.PAMINNELSE,
                 EventCode.KOMPLBEGARAN,
                 EventCode.SKAPATFRAN
             );

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/question/GetQuestionsFacadeServiceImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/question/GetQuestionsFacadeServiceImplTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.inera.intyg.common.support.facade.model.Certificate;
 import se.inera.intyg.common.support.facade.model.CertificateRelationType;
+import se.inera.intyg.common.support.facade.model.CertificateStatus;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateMetadata;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateRelation;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateRelations;
@@ -224,6 +225,23 @@ public class GetQuestionsFacadeServiceImplTest {
 
         assertEquals(1, actualQuestions.size(), "Expect one question");
         assertEquals(answeredByCertificate, answeredByCertificateArgCaptor.getValue());
+    }
+
+    @Test
+    void shallReturnQuestionWithComplementButNoAnsweredByCertificateIfRevoked() {
+        final var answeredByCertificate = CertificateRelation.builder()
+            .type(CertificateRelationType.COMPLEMENTED)
+            .created(LocalDateTime.now().plus(1, ChronoUnit.DAYS))
+            .status(CertificateStatus.REVOKED)
+            .build();
+
+        final var answeredByCertificateArgCaptor =
+            setupMockToReturnQuestionsWithComplementAndAnsweredByCertificate(new CertificateRelation[]{answeredByCertificate});
+
+        final var actualQuestions = getQuestionsFacadeService.getQuestions(CERTIFICATE_ID);
+
+        assertEquals(1, actualQuestions.size(), "Expect one question");
+        assertNull(answeredByCertificateArgCaptor.getValue(), "Expect answeredByCertificate to be null because it is revoked");
     }
 
     @Test

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/question/util/QuestionConverterImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/question/util/QuestionConverterImplTest.java
@@ -214,7 +214,7 @@ class QuestionConverterImplTest {
             arende = new Arende();
             arende.setMeddelandeId(QUESTION_ID);
             arende.setVardaktorName(AUTHOR);
-            arende.setAmne(ArendeAmne.AVSTMN);
+            arende.setAmne(ArendeAmne.KOMPLT);
             arende.setSkickatTidpunkt(SENT);
             arende.setSkickatAv(SENT_BY_FK);
             arende.setStatus(Status.CLOSED);


### PR DESCRIPTION
… client. Also filter out any duplicates of request for complements, due to a bug in Webcert certificate event creation. Make sure that answerByCertificate is not included for non complement questions.