### PR TITLE
INTYGFV-14280: Use issuedBy from the certificate, converted from json…

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/IntygToCertificateConverterImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/IntygToCertificateConverterImpl.java
@@ -111,10 +111,6 @@ public class IntygToCertificateConverterImpl implements IntygToCertificateConver
             )
         );
 
-        certificateToReturn.getMetadata().setIssuedBy(
-            getIssuedBy(certificate.getUtlatande().getGrundData().getSkapadAv())
-        );
-
         certificateToReturn.getMetadata().setRelations(
             certificateRelationsConverter.convert(certificateToReturn.getMetadata().getId())
         );
@@ -125,15 +121,6 @@ public class IntygToCertificateConverterImpl implements IntygToCertificateConver
         );
 
         return certificateToReturn;
-    }
-
-    private Staff getIssuedBy(HoSPersonal skapadAv) {
-        final var staff = new Staff();
-
-        staff.setPersonId(skapadAv.getPersonId());
-        staff.setFullName(skapadAv.getFullstandigtNamn());
-
-        return staff;
     }
 
     private Unit getCareProvider(HoSPersonal skapadAv) {

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/UtkastToCertificateConverterImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/UtkastToCertificateConverterImpl.java
@@ -107,10 +107,6 @@ public class UtkastToCertificateConverterImpl implements UtkastToCertificateConv
             )
         );
 
-        certificateToReturn.getMetadata().setIssuedBy(
-            getIssuedBy(certificate)
-        );
-
         certificateToReturn.getMetadata().setRelations(
             certificateRelationsConverter.convert(certificateToReturn.getMetadata().getId())
         );
@@ -125,15 +121,6 @@ public class UtkastToCertificateConverterImpl implements UtkastToCertificateConv
         );
 
         return certificateToReturn;
-    }
-
-    private Staff getIssuedBy(Utkast certificate) {
-        final var staff = new Staff();
-
-        staff.setPersonId(certificate.getSkapadAv().getHsaId());
-        staff.setFullName(certificate.getSkapadAv().getNamn());
-
-        return staff;
     }
 
     private Unit getCareProvider(Utkast certificate) {

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/IntygToCertificateConverterImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/IntygToCertificateConverterImplTest.java
@@ -45,6 +45,7 @@ import se.inera.intyg.common.support.facade.model.Certificate;
 import se.inera.intyg.common.support.facade.model.CertificateStatus;
 import se.inera.intyg.common.support.facade.model.Patient;
 import se.inera.intyg.common.support.facade.model.PersonId;
+import se.inera.intyg.common.support.facade.model.Staff;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateMetadata;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateRelations;
 import se.inera.intyg.common.support.facade.model.metadata.Unit;
@@ -79,6 +80,8 @@ public class IntygToCertificateConverterImplTest {
     public static final String UNIT_ID = "unitId";
     public static final String PERSON_ID = "PersonId";
     public static final String PERSON_NAME = "Doctor Alpha";
+    public static final String PERSON_ID_FROM_JSON = "PersonId - json";
+    public static final String PERSON_NAME_FROM_JSON = "Doctor Alpha - json";
 
     @Mock
     private IntygModuleRegistry moduleRegistry;
@@ -260,7 +263,7 @@ public class IntygToCertificateConverterImplTest {
 
         @Test
         void shallIncludePersonId() {
-            final var expectedPersonId = PERSON_ID;
+            final var expectedPersonId = PERSON_ID_FROM_JSON;
 
             final var actualCertificate = intygToCertificateConverter.convert(intygContentHolder);
 
@@ -269,7 +272,7 @@ public class IntygToCertificateConverterImplTest {
 
         @Test
         void shallIncludeName() {
-            final var expectedFullName = PERSON_NAME;
+            final var expectedFullName = PERSON_NAME_FROM_JSON;
 
             final var actualCertificate = intygToCertificateConverter.convert(intygContentHolder);
 
@@ -367,6 +370,12 @@ public class IntygToCertificateConverterImplTest {
                             .city("city")
                             .email("email")
                             .phoneNumber("phoneNumber")
+                            .build()
+                    )
+                    .issuedBy(
+                        Staff.builder()
+                            .personId(PERSON_ID_FROM_JSON)
+                            .fullName(PERSON_NAME_FROM_JSON)
                             .build()
                     )
                     .build()

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/UtkastToCertificateConverterTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/UtkastToCertificateConverterTest.java
@@ -45,6 +45,7 @@ import se.inera.intyg.common.support.facade.model.Certificate;
 import se.inera.intyg.common.support.facade.model.CertificateStatus;
 import se.inera.intyg.common.support.facade.model.Patient;
 import se.inera.intyg.common.support.facade.model.PersonId;
+import se.inera.intyg.common.support.facade.model.Staff;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateMetadata;
 import se.inera.intyg.common.support.facade.model.metadata.CertificateRelations;
 import se.inera.intyg.common.support.facade.model.metadata.Unit;
@@ -90,6 +91,8 @@ public class UtkastToCertificateConverterTest {
 
     private static final String CARE_UNIT_ID = "careUnitId";
     private static final String CARE_UNIT_NAME = "careUnitName";
+    private static final String PERSON_ID_FROM_JSON = "PersonId - json";
+    private static final String PERSON_NAME_FROM_JSON = "Doctor Alpha - json";
 
     @BeforeEach
     void setupMocks() throws Exception {
@@ -243,8 +246,8 @@ public class UtkastToCertificateConverterTest {
 
         @Test
         void shallIncludePersonId() {
-            final var expectedPersonId = "PersonId";
-            draft.getSkapadAv().setHsaId(expectedPersonId);
+            final var expectedPersonId = PERSON_ID_FROM_JSON;
+            draft.getSkapadAv().setHsaId("PersonId from utkast");
 
             final var actualCertificate = utkastToCertificateConverter.convert(draft);
 
@@ -253,8 +256,8 @@ public class UtkastToCertificateConverterTest {
 
         @Test
         void shallIncludeName() {
-            final var expectedFullName = "Doctor Alpha";
-            draft.getSkapadAv().setNamn(expectedFullName);
+            final var expectedFullName = PERSON_NAME_FROM_JSON;
+            draft.getSkapadAv().setNamn("Person name from utkast");
 
             final var actualCertificate = utkastToCertificateConverter.convert(draft);
 
@@ -395,6 +398,12 @@ public class UtkastToCertificateConverterTest {
                             .city("city")
                             .email("email")
                             .phoneNumber("phoneNumber")
+                            .build()
+                    )
+                    .issuedBy(
+                        Staff.builder()
+                            .personId(PERSON_ID_FROM_JSON)
+                            .fullName(PERSON_NAME_FROM_JSON)
                             .build()
                     )
                     .build()


### PR DESCRIPTION
…, instead of specific 'created by' properties. The latter will be not be updated if the doctor´s name changes during issuing of the certificate.