### PR TITLE
INTYGFV-14614: And logic for alternate patient id and reserve id

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateResourceLinksImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/impl/GetCertificateResourceLinksImpl.java
@@ -223,7 +223,7 @@ public class GetCertificateResourceLinksImpl implements GetCertificateResourceLi
 
     private Personnummer getPatientId(Patient patient) {
         String patientId = patient.getPersonId().getId();
-        if (patient.getPreviousPersonId() != null && !patient.isPersonIdUpdated()) {
+        if (patient.getPreviousPersonId() != null) {
             patientId = patient.getPreviousPersonId().getId();
         }
         return Personnummer.createPersonnummer(patientId).orElseThrow();

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/PatientConverterImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/facade/util/PatientConverterImpl.java
@@ -61,7 +61,6 @@ public class PatientConverterImpl implements PatientConverter {
             .deceased(patient.isAvliden())
             .differentNameFromEHR(isPatientNameDifferent(patient, parameters))
             .previousPersonId(getPreviousPersonId(patientId, parameters))
-            .personIdUpdated(isPatientIdUpdated(parameters, patientId))
             .personIdChanged(isPatientIdChanged(parameters, patientId))
             .reserveId(hasReserveId(parameters, patientId))
             .build();
@@ -92,10 +91,6 @@ public class PatientConverterImpl implements PatientConverter {
         return Personnummer.createPersonnummer(id).isPresent();
     }
 
-    private boolean isPatientIdUpdated(IntegrationParameters parameters, Personnummer patientId) {
-        return isBeforeAlternateSSNSet(parameters) && !isPersonIdSameAsBeforeAlternateSSN(patientId, parameters);
-    }
-
     private String getString(String s) {
         return s != null ? s : "";
     }
@@ -113,10 +108,6 @@ public class PatientConverterImpl implements PatientConverter {
             .id(id)
             .type("PERSON_NUMMER")
             .build();
-    }
-
-    private boolean isPersonIdSameAsBeforeAlternateSSN(Personnummer patientId, IntegrationParameters parameters) {
-        return parameters != null && compareWithAndWithoutDash(patientId, parameters.getBeforeAlternateSsn());
     }
 
     private boolean isPersonIdSameAsAlternateSSN(Personnummer patientId, IntegrationParameters parameters) {
@@ -149,7 +140,7 @@ public class PatientConverterImpl implements PatientConverter {
     }
 
     private PersonId getPreviousPersonId(Personnummer patientId, IntegrationParameters parameters) {
-        if (isPatientIdNotChanged(patientId, parameters)) {
+        if (!isPatientIdChanged(parameters, patientId)) {
             return null;
         } else if (!isBeforeAlternateSSNSet(parameters)) {
             return PersonId.builder()
@@ -161,12 +152,6 @@ public class PatientConverterImpl implements PatientConverter {
             .id(parameters.getBeforeAlternateSsn())
             .type("PERSON_NUMMER")
             .build();
-    }
-
-    private boolean isPatientIdNotChanged(Personnummer patientId, IntegrationParameters parameters) {
-        return parameters == null
-            || (isPersonIdSameAsAlternateSSN(patientId, parameters) && !isPatientIdUpdated(parameters, patientId))
-            || !isAlternateSSNSet(parameters);
     }
 
     private boolean isAlternateSSNSet(IntegrationParameters parameters) {

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/PatientConverterImplTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/facade/util/PatientConverterImplTest.java
@@ -141,7 +141,6 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(ALTERNATE_PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(ALTERNATE_PATIENT_ID, patient.getPersonId().getId());
-                    assertTrue(patient.isPersonIdUpdated());
                     assertTrue(patient.isPersonIdChanged());
                 }
 
@@ -151,7 +150,6 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(PATIENT_ID, patient.getPersonId().getId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertFalse(patient.isPersonIdChanged());
                 }
 
@@ -161,17 +159,15 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(PATIENT_ID, patient.getPersonId().getId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertFalse(patient.isPersonIdChanged());
                 }
 
                 @Test
-                public void shallHaveAlternateSSNAsPatientIdIfPatientIdHasNotBeenReplaced() {
+                public void shallHaveAlternateSSNAsPatientIdIfSet() {
                     final var parameters = getIntegrationParameters(ALTERNATE_PATIENT_ID, FIRSTNAME, LASTNAME);
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(ALTERNATE_PATIENT_ID, patient.getPersonId().getId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertTrue(patient.isPersonIdChanged());
                 }
             }
@@ -185,7 +181,6 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertNull(patient.getPreviousPersonId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertFalse(patient.isPersonIdChanged());
                 }
 
@@ -195,7 +190,6 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertNull(patient.getPreviousPersonId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertFalse(patient.isPersonIdChanged());
                 }
 
@@ -206,7 +200,6 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(ALTERNATE_PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(PATIENT_ID, patient.getPreviousPersonId().getId());
-                    assertTrue(patient.isPersonIdUpdated());
                     assertTrue(patient.isPersonIdChanged());
                 }
 
@@ -217,36 +210,7 @@ class PatientConverterImplTest {
                     user.setParameters(parameters);
                     final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                     assertEquals(PATIENT_ID, patient.getPreviousPersonId().getId());
-                    assertFalse(patient.isPersonIdUpdated());
                     assertTrue(patient.isPersonIdChanged());
-                }
-            }
-
-            @Nested
-            class PersonIdUpdatedFlag {
-
-                @Test
-                public void shallSetFlagIfPersonIdIsReplaced() {
-                    final var parameters = getIntegrationParameters(ALTERNATE_PATIENT_ID, FIRSTNAME, LASTNAME);
-                    parameters.setBeforeAlternateSsn(PATIENT_ID);
-                    user.setParameters(parameters);
-                    final var patient = patientConverter.convert(ALTERNATE_PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
-                    assertTrue(patient.isPersonIdUpdated());
-                }
-
-                @Test
-                public void shallNotSetFlagIfPersonIdIsNotReplaced() {
-                    final var parameters = getIntegrationParameters(ALTERNATE_PATIENT_ID, FIRSTNAME, LASTNAME);
-                    parameters.setBeforeAlternateSsn(PATIENT_ID);
-                    user.setParameters(parameters);
-                    final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
-                    assertFalse(patient.isPersonIdUpdated());
-                }
-
-                @Test
-                public void shallNotSetFlagForPersonIdIfNoParametersAreSent() {
-                    final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
-                    assertFalse(patient.isPersonIdUpdated());
                 }
             }
 
@@ -380,7 +344,7 @@ class PatientConverterImplTest {
             public void shallNotStausesIfNoIntegrationParameters() {
                 final var patient = patientConverter.convert(PERSON_NUMMER, CERTIFICATE_TYPE, CERTIFICATE_TYPE_VERSION);
                 assertFalse(patient.isDifferentNameFromEHR());
-                assertFalse(patient.isPersonIdUpdated());
+                assertFalse(patient.isPersonIdChanged());
             }
         }
     }


### PR DESCRIPTION
This implementation more closely matches the one in the old AngularJS client:

Person id is changed if
* beforeAlternateSSN is set AND alternateSSN is set AND beforeAlternateSSN != alternateSSN AND alternateSSN is a personId/coordinationId
      OR
* beforeAlternateSSN is NOT set AND personId is set AND personId != alternateSSN AND alternateSSN is a personId/coordinationId

Has reserve id if

 * beforeAlternateSSN is NOT set AND personId is set AND personId != alternateSSN AND alternateSSN is NOT a personId/coordinationId