### PR TITLE
INTYGFV-16495: Should set certificates to collections empty list if error from IT when trying to get signed certificates.

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/certificate/CertificateServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/certificate/CertificateServiceImpl.java
@@ -18,6 +18,7 @@
  */
 package se.inera.intyg.webcert.web.service.certificate;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -82,6 +83,7 @@ public class CertificateServiceImpl implements CertificateService {
             LOGGER.error("Could not get list of signed certificates for unit from IT", ex);
             CertificateListResponse certificateListResponse = new CertificateListResponse();
             certificateListResponse.setErrorFromIT(true);
+            certificateListResponse.setCertificates(Collections.emptyList());
             return certificateListResponse;
         }
     }

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/certificate/CertificateServiceTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/certificate/CertificateServiceTest.java
@@ -83,6 +83,14 @@ public class CertificateServiceTest {
     }
 
     @Test
+    public void shouldReturnListOfEmptyCertificatesIfErrorGettingCertificatesFromIT() {
+        Mockito.when(itIntegrationService.getCertificatesForDoctor(null, null)).thenReturn(null);
+        var certificateListResponse = certificateService.listCertificatesForDoctor(null);
+        verify(logService, times(0)).logListIntyg(any(), any());
+        assertTrue(certificateListResponse.getCertificates().isEmpty());
+    }
+
+    @Test
     public void decoratePatientWithAllFlags() {
         testDecorateWithPatientFlags(true, false);
     }


### PR DESCRIPTION
Related to this code that calls this function:

```java
        final var listFromWC = certificateService.listCertificatesForDoctor(convertedFilter);
        final var convertedListFromWC = listFromWC.getCertificates().stream()
            .map(certificateListItemConverter::convert)
            .collect(Collectors.toList());
```

Currently we are recieving a NullPointer if there is an error in the communication with IT.