### PR TITLE
TESTENV: Opt out from status updates and pdf log when creating drafts from testability api

### DIFF
--- a/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/UtkastServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/UtkastServiceImpl.java
@@ -221,6 +221,13 @@ public class UtkastServiceImpl implements UtkastService {
             generateCertificateEvent(savedUtkast, EventCode.KFSIGN);
         }
 
+        // If testability is set, return the draft without sending notifications or pdl log
+        if (request.isTestability()) {
+            monitoringService.logUtkastCreated(savedUtkast.getIntygsId(), savedUtkast.getIntygsTyp(),
+                savedUtkast.getEnhetsId(), savedUtkast.getSkapadAv().getHsaId(), nrPrefillElements);
+            return savedUtkast;
+        }
+
         // Notify stakeholders when a draft has been created
         sendNotification(savedUtkast, Event.CREATED);
 

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/dto/CreateNewDraftRequest.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/utkast/dto/CreateNewDraftRequest.java
@@ -19,12 +19,15 @@
 package se.inera.intyg.webcert.web.service.utkast.dto;
 
 import java.util.Optional;
-
+import lombok.Getter;
+import lombok.Setter;
 import se.inera.intyg.common.support.model.UtkastStatus;
 import se.inera.intyg.common.support.model.common.internal.HoSPersonal;
 import se.inera.intyg.common.support.model.common.internal.Patient;
 import se.riv.clinicalprocess.healthcond.certificate.v33.Forifyllnad;
 
+@Getter
+@Setter
 public class CreateNewDraftRequest {
 
     private String intygId;
@@ -42,6 +45,8 @@ public class CreateNewDraftRequest {
     private HoSPersonal hosPerson;
 
     private Optional<Forifyllnad> forifyllnad = Optional.empty();
+
+    private boolean testability = false;
 
     public CreateNewDraftRequest() {
         // Needed for deserialization
@@ -65,68 +70,4 @@ public class CreateNewDraftRequest {
         this.forifyllnad = forifyllnad;
     }
     // CHECKSTYLE:ON ParameterNumber
-
-    public String getIntygId() {
-        return intygId;
-    }
-
-    public void setIntygId(String intygId) {
-        this.intygId = intygId;
-    }
-
-    public String getIntygType() {
-        return intygType;
-    }
-
-    public void setIntygType(String intygType) {
-        this.intygType = intygType;
-    }
-
-    public UtkastStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(UtkastStatus status) {
-        this.status = status;
-    }
-
-    public Patient getPatient() {
-        return patient;
-    }
-
-    public void setPatient(Patient patient) {
-        this.patient = patient;
-    }
-
-    public HoSPersonal getHosPerson() {
-        return hosPerson;
-    }
-
-    public void setHosPerson(HoSPersonal hosPerson) {
-        this.hosPerson = hosPerson;
-    }
-
-    public String getReferens() {
-        return referens;
-    }
-
-    public void setReferens(String referens) {
-        this.referens = referens;
-    }
-
-    public String getIntygTypeVersion() {
-        return intygTypeVersion;
-    }
-
-    public void setIntygTypeVersion(String intygTypeVersion) {
-        this.intygTypeVersion = intygTypeVersion;
-    }
-
-    public Optional<Forifyllnad> getForifyllnad() {
-        return forifyllnad;
-    }
-
-    public void setForifyllnad(Optional<Forifyllnad> forifyllnad) {
-        this.forifyllnad = forifyllnad;
-    }
 }

--- a/web/src/main/java/se/inera/intyg/webcert/web/web/controller/testability/facade/util/CreateCertificateTestabilityUtil.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/web/controller/testability/facade/util/CreateCertificateTestabilityUtil.java
@@ -126,6 +126,8 @@ public class CreateCertificateTestabilityUtil {
             patient
         );
 
+        createNewDraftRequest.setTestability(true);
+
         final var utkast = createNewDraft(createNewDraftRequest);
         final var updateJsonModel = getUpdateJsonModel(utkast, createCertificateRequest);
         utkast.setModel(updateJsonModel);


### PR DESCRIPTION
This makes it possible to validate status updates and pdf-logging correctly