### PR TITLE
K1J-1393: Improve exception handling in processors for certificate (notification_sender). Always rethrow with original exception and message for context. Remove extra logging within catch-block, because the message-handler will anyway log the error.

### DIFF
--- a/common/src/main/java/se/inera/intyg/webcert/common/sender/exception/TemporaryException.java
+++ b/common/src/main/java/se/inera/intyg/webcert/common/sender/exception/TemporaryException.java
@@ -30,4 +30,8 @@ public class TemporaryException extends Exception {
         super(cause);
     }
 
+    public TemporaryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateSendProcessor.java
+++ b/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateSendProcessor.java
@@ -41,7 +41,7 @@ public class CertificateSendProcessor {
     @Autowired
     private SendCertificateServiceClient sendServiceClient;
     @Autowired
-    private  MdcHelper mdcHelper;
+    private MdcHelper mdcHelper;
 
     public void process(@Body String skickatAv,
         @Header(Constants.INTYGS_ID) String intygsId,
@@ -69,10 +69,11 @@ public class CertificateSendProcessor {
                     LOG.warn("Warning occured when trying to send intyg '{}'; {}. Will not requeue.", intygsId, resultText);
                 }
             }
-
         } catch (WebServiceException e) {
-            LOG.warn("Call to send intyg {} caused an error: {}. Will retry", intygsId, e.getMessage());
-            throw new TemporaryException(e.getMessage());
+            throw new TemporaryException(
+                "Call to send intyg '%s' caused an error: '%s'. Will retry".formatted(intygsId, e.getMessage()),
+                e
+            );
         } finally {
             MDC.clear();
         }

--- a/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessor.java
+++ b/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/CertificateStoreProcessor.java
@@ -56,7 +56,10 @@ public class CertificateStoreProcessor {
             moduleApi.registerCertificate(utkastAsJson, logicalAddress);
 
         } catch (Exception e) {
-            throw new TemporaryException(e);
+            throw new TemporaryException(
+                "Error occurred when trying to store certificate of type '%s' in intygstjansten.".formatted(intygsTyp),
+                e
+            );
         } finally {
             MDC.clear();
         }

--- a/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/SendMessageToRecipientProcessor.java
+++ b/notification-sender/src/main/java/se/inera/intyg/webcert/notification_sender/certificatesender/services/SendMessageToRecipientProcessor.java
@@ -61,23 +61,20 @@ public class SendMessageToRecipientProcessor {
             ResultType result = response.getResult();
 
             switch (result.getResultCode()) {
-                case OK:
-                case INFO:
+                case OK, INFO:
                     return;
                 case ERROR:
-                    LOG.error(
-                        "Call to sendMessageToRecipient for intyg {} caused an error: {}, ErrorId: {}."
-                            + " Rethrowing as PermanentException", intygsId, result.getResultText(), result.getErrorId());
-                    throw new TemporaryException(result.getResultText());
+                    throw new TemporaryException(
+                        "Call to sendMessageToRecipient for intyg '%s' caused an error: '%s', ErrorId: '%s'.  Will retry"
+                            .formatted(intygsId, result.getResultText(), result.getErrorId())
+                    );
             }
-        } catch (UnmarshallingFailureException e) {
-            LOG.error("Call to sendMessageToRecipient for intyg {} caused an error: {}. Rethrowing as PermanentException",
-                intygsId, e.getMessage());
-            throw new TemporaryException(e.getMessage());
-        } catch (WebServiceException e) {
-            LOG.error("Call to sendMessageToRecipient for intyg {} caused an error: {}. Will retry",
-                intygsId, e.getMessage());
-            throw new TemporaryException(e.getMessage());
+        } catch (UnmarshallingFailureException | WebServiceException e) {
+            throw new TemporaryException(
+                "Call to sendMessageToRecipient for intyg '%s' caused an error: '%s'. Will retry"
+                    .formatted(intygsId, e.getMessage()),
+                e
+            );
         } finally {
             MDC.clear();
         }


### PR DESCRIPTION
We had an incident with a SendMessageToRecipient not being able to be parsed. Due to the logs not including the original exception, it makes it harder to pinpoint the exact place there the issue occurs. 

This PR is to improve the exception handling for all processors within se.inera.intyg.webcert.notification_sender.certificatesender

I did ignore the RegisterApprovedReceiversProcessor as it is no longer used. I looked at the opportunity to remove the code related to "Receivers", but it wasn't as straightforward as I initially thought. Therefore I keep this PR small and only improve the exception-handling.