### PR TITLE
K1J-1450: Publish messages to certificate-analytics-service for events relating to CreateDraftCertificate including with prefill

### DIFF
--- a/integration-certificate-analytics-service/src/main/java/se/inera/intyg/webcert/integration/analytics/model/CertificateAnalyticsMessageType.java
+++ b/integration-certificate-analytics-service/src/main/java/se/inera/intyg/webcert/integration/analytics/model/CertificateAnalyticsMessageType.java
@@ -20,6 +20,7 @@ package se.inera.intyg.webcert.integration.analytics.model;
 
 public enum CertificateAnalyticsMessageType {
     DRAFT_CREATED,
+    DRAFT_CREATED_WITH_PREFILL,
     DRAFT_DELETED,
     DRAFT_UPDATED,
     DRAFT_READY_FOR_SIGN,

--- a/integration-certificate-analytics-service/src/test/java/se/inera/intyg/webcert/integration/analytics/service/CertificateAnalyticsMessageFactoryTest.java
+++ b/integration-certificate-analytics-service/src/test/java/se/inera/intyg/webcert/integration/analytics/service/CertificateAnalyticsMessageFactoryTest.java
@@ -363,6 +363,219 @@ class CertificateAnalyticsMessageFactoryTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AnalyticsMessagesBasedOnCertificateWithoutLoggedInUser {
+
+        private Certificate certificate;
+        private LoggedInWebcertUser loggedInWebcertUser;
+
+        @BeforeEach
+        void setUp() {
+            certificate = new Certificate();
+            certificate.setMetadata(
+                CertificateMetadata.builder()
+                    .id(CERTIFICATE_ID)
+                    .type(CERTIFICATE_TYPE)
+                    .typeVersion(CERTIFICATE_TYPE_VERSION)
+                    .patient(
+                        Patient.builder()
+                            .personId(
+                                PersonId.builder()
+                                    .id(CERTIFICATE_PATIENT_ID)
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .unit(
+                        Unit.builder()
+                            .unitId(CERTIFICATE_UNIT_ID)
+                            .build()
+                    )
+                    .careProvider(
+                        Unit.builder()
+                            .unitId(CERTIFICATE_CARE_PROVIDER_ID)
+                            .build()
+                    )
+                    .recipient(
+                        CertificateRecipient.builder()
+                            .id(RECIPIENT_ID)
+                            .build()
+                    )
+                    .relations(
+                        CertificateRelations.builder()
+                            .parent(
+                                CertificateRelation.builder()
+                                    .certificateId(CERTIFICATE_RELATION_PARENT_ID)
+                                    .type(CERTIFICATE_RELATION_PARENT_TYPE)
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .build()
+            );
+
+            loggedInWebcertUser = LoggedInWebcertUser.builder()
+                .staffId(EVENT_USER_ID)
+                .role(EVENT_ROLE)
+                .unitId(EVENT_UNIT_ID)
+                .careProviderId(EVENT_CARE_PROVIDER_ID)
+                .build();
+
+            MDC.put(MdcLogConstants.SESSION_ID_KEY, "-");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventTimestamp(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertNotNull(actual.getEvent().getTimestamp());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventMessageType(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(messageType, actual.getEvent().getMessageType());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventStaffId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(EVENT_USER_ID, actual.getEvent().getUserId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventRole(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(EVENT_ROLE, actual.getEvent().getRole());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventUnitId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(EVENT_UNIT_ID, actual.getEvent().getUnitId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventCareProviderId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(EVENT_CARE_PROVIDER_ID, actual.getEvent().getCareProviderId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventOrigin(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertNull(actual.getEvent().getOrigin(), "Origin should be null when no user logged in");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventSessionId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertNull(actual.getEvent().getSessionId(), "SessionId should be null when no user logged in");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_ID, actual.getCertificate().getId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateType(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_TYPE, actual.getCertificate().getType());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateTypeVersion(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_TYPE_VERSION, actual.getCertificate().getTypeVersion());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificatePatientId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_PATIENT_ID, actual.getCertificate().getPatientId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateUnitId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_UNIT_ID, actual.getCertificate().getUnitId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateCareProviderId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_CARE_PROVIDER_ID, actual.getCertificate().getCareProviderId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateRelationParentId(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_RELATION_PARENT_ID, actual.getCertificate().getParent().getId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateRelationParentType(Function<CertificateAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(CertificateAndUser.create(certificate, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_RELATION_PARENT_TYPE.name(), actual.getCertificate().getParent().getType());
+        }
+
+        Stream<Arguments> analyticsMessagesBasedOnCertificateWithoutLoggedInUser() {
+            return Stream.of(
+                Arguments.of(
+                    (Function<CertificateAndUser, CertificateAnalyticsMessage>) certificateAndUser ->
+                        factory.draftCreated(certificateAndUser.certificate(), certificateAndUser.user()),
+                    CertificateAnalyticsMessageType.DRAFT_CREATED
+                ),
+                Arguments.of(
+                    (Function<CertificateAndUser, CertificateAnalyticsMessage>) certificateAndUser ->
+                        factory.draftCreatedWithPrefill(certificateAndUser.certificate(), certificateAndUser.user()),
+                    CertificateAnalyticsMessageType.DRAFT_CREATED_WITH_PREFILL
+                )
+            );
+        }
+
+        record CertificateAndUser(Certificate certificate, LoggedInWebcertUser user) {
+
+            public static CertificateAndUser create(Certificate certificate, LoggedInWebcertUser user) {
+                return new CertificateAndUser(certificate, user);
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class AnalyticsMessagesBasedOnUtkast {
 
         private Utkast utkast;
@@ -577,6 +790,187 @@ class CertificateAnalyticsMessageFactoryTest {
                     CertificateAnalyticsMessageType.CERTIFICATE_COMPLEMENTED
                 )
             );
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AnalyticsMessagesBasedOnUtkastWithoutLoggedInUser {
+
+        private Utkast utkast;
+        private LoggedInWebcertUser loggedInWebcertUser;
+
+        @BeforeEach
+        void setUp() {
+            utkast = new Utkast();
+            utkast.setIntygsId(CERTIFICATE_ID);
+            utkast.setIntygsTyp(CERTIFICATE_TYPE);
+            utkast.setIntygTypeVersion(CERTIFICATE_TYPE_VERSION);
+            utkast.setPatientPersonnummer(Personnummer.createPersonnummer(CERTIFICATE_PATIENT_ID).orElseThrow());
+            utkast.setEnhetsId(CERTIFICATE_UNIT_ID);
+            utkast.setVardgivarId(CERTIFICATE_CARE_PROVIDER_ID);
+            utkast.setSkickadTillMottagare(RECIPIENT_ID);
+            utkast.setRelationIntygsId(CERTIFICATE_RELATION_PARENT_ID);
+            utkast.setRelationKod(RelationKod.FRLANG);
+
+            loggedInWebcertUser = LoggedInWebcertUser.builder()
+                .staffId(EVENT_USER_ID)
+                .role(EVENT_ROLE)
+                .unitId(EVENT_UNIT_ID)
+                .careProviderId(EVENT_CARE_PROVIDER_ID)
+                .build();
+
+            MDC.put(MdcLogConstants.SESSION_ID_KEY, "-");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventTimestamp(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertNotNull(actual.getEvent().getTimestamp());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventMessageType(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(messageType, actual.getEvent().getMessageType());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventStaffId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(EVENT_USER_ID, actual.getEvent().getUserId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventRole(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(EVENT_ROLE, actual.getEvent().getRole());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventUnitId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(EVENT_UNIT_ID, actual.getEvent().getUnitId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventCareProviderId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(EVENT_CARE_PROVIDER_ID, actual.getEvent().getCareProviderId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventOrigin(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertNull(actual.getEvent().getOrigin(), "Origin should be null when no user logged in");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectEventSessionId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertNull(actual.getEvent().getSessionId(), "SessionId should be null when no user logged in");
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_ID, actual.getCertificate().getId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateType(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_TYPE, actual.getCertificate().getType());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateTypeVersion(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_TYPE_VERSION, actual.getCertificate().getTypeVersion());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificatePatientId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_PATIENT_ID, actual.getCertificate().getPatientId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateUnitId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_UNIT_ID, actual.getCertificate().getUnitId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateCareProviderId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_CARE_PROVIDER_ID, actual.getCertificate().getCareProviderId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateRelationParentId(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_RELATION_PARENT_ID, actual.getCertificate().getParent().getId());
+        }
+
+        @ParameterizedTest(name = "{index} => {1}")
+        @MethodSource("analyticsMessagesBasedOnCertificateWithoutLoggedInUser")
+        void shallReturnCorrectCertificateRelationParentType(Function<UtkastAndUser, CertificateAnalyticsMessage> test,
+            CertificateAnalyticsMessageType messageType) {
+            final var actual = test.apply(UtkastAndUser.create(utkast, loggedInWebcertUser));
+            assertEquals(CERTIFICATE_RELATION_PARENT_TYPE.name(), actual.getCertificate().getParent().getType());
+        }
+
+        Stream<Arguments> analyticsMessagesBasedOnCertificateWithoutLoggedInUser() {
+            return Stream.of(
+                Arguments.of(
+                    (Function<UtkastAndUser, CertificateAnalyticsMessage>) utkastAndUser ->
+                        factory.draftCreated(utkastAndUser.certificate(), utkastAndUser.user()),
+                    CertificateAnalyticsMessageType.DRAFT_CREATED
+                ),
+                Arguments.of(
+                    (Function<UtkastAndUser, CertificateAnalyticsMessage>) utkastAndUser ->
+                        factory.draftCreatedWithPrefill(utkastAndUser.certificate(), utkastAndUser.user()),
+                    CertificateAnalyticsMessageType.DRAFT_CREATED_WITH_PREFILL
+                )
+            );
+        }
+
+        record UtkastAndUser(Utkast certificate, LoggedInWebcertUser user) {
+
+            public static UtkastAndUser create(Utkast utkast, LoggedInWebcertUser user) {
+                return new UtkastAndUser(utkast, user);
+            }
         }
     }
 
@@ -817,7 +1211,7 @@ class CertificateAnalyticsMessageFactoryTest {
 
             when(loggedInWebcertUserService.getLoggedInWebcertUser()).thenReturn(noLoggedInUser);
 
-            MDC.clear();
+            MDC.put(MdcLogConstants.SESSION_ID_KEY, "-");
         }
 
         @Test
@@ -1483,7 +1877,7 @@ class CertificateAnalyticsMessageFactoryTest {
             // Make this lenient to enable mocking to work in parameterized tests
             lenient().when(loggedInWebcertUserService.getLoggedInWebcertUser()).thenReturn(noLoggedInUser);
 
-            MDC.clear();
+            MDC.put(MdcLogConstants.SESSION_ID_KEY, "-");
         }
 
         @Test

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/user/LoggedInWebcertUserFactory.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/user/LoggedInWebcertUserFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Inera AB (http://www.inera.se)
+ *
+ * This file is part of sklintyg (https://github.com/sklintyg).
+ *
+ * sklintyg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * sklintyg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.inera.intyg.webcert.web.service.user;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import se.inera.intyg.infra.security.common.model.IntygUser;
+import se.inera.intyg.infra.security.common.model.Role;
+import se.inera.intyg.webcert.common.service.user.LoggedInWebcertUser;
+import se.inera.intyg.webcert.web.service.user.dto.WebCertUser;
+
+@Component
+public class LoggedInWebcertUserFactory {
+
+    public LoggedInWebcertUser create(IntygUser user) {
+        return LoggedInWebcertUser.builder()
+            .staffId(user.getHsaId())
+            .role(role(user.getRoles()))
+            .unitId(selectedUnitId(user))
+            .careProviderId(selectedCareProviderId(user))
+            .build();
+    }
+
+    public LoggedInWebcertUser create(WebCertUser user) {
+        return LoggedInWebcertUser.builder()
+            .staffId(user.getHsaId())
+            .role(role(user.getRoles()))
+            .unitId(selectedUnitId(user))
+            .careProviderId(selectedCareProviderId(user))
+            .origin(user.getOrigin())
+            .build();
+    }
+
+    private static String selectedUnitId(IntygUser user) {
+        final var valdVardenhet = user.getValdVardenhet();
+        return valdVardenhet == null ? null : valdVardenhet.getId();
+    }
+
+    private static String selectedCareProviderId(IntygUser user) {
+        final var valdVardgivare = user.getValdVardgivare();
+        return valdVardgivare == null ? null : valdVardgivare.getId();
+    }
+
+    private String role(Map<String, Role> roles) {
+        return roles != null && roles.size() == 1 ? roles.keySet().iterator().next() : null;
+    }
+}

--- a/web/src/main/java/se/inera/intyg/webcert/web/service/user/WebCertUserServiceImpl.java
+++ b/web/src/main/java/se/inera/intyg/webcert/web/service/user/WebCertUserServiceImpl.java
@@ -53,6 +53,7 @@ public class WebCertUserServiceImpl implements WebCertUserService, LoggedInWebce
     private final CommonAuthoritiesResolver authoritiesResolver;
     private final AnvandarPreferenceRepository anvandarPreferenceRepository;
     private final FindByIndexNameSessionRepository<?> sessionRepository;
+    private final LoggedInWebcertUserFactory loggedInWebcertUserFactory;
 
     @Value("${logout.timeout.seconds}")
     private int logoutTimeout;
@@ -207,16 +208,6 @@ public class WebCertUserServiceImpl implements WebCertUserService, LoggedInWebce
             return LoggedInWebcertUser.builder().build();
         }
 
-        return LoggedInWebcertUser.builder()
-            .staffId(getUser().getHsaId())
-            .role(role(user.getRoles()))
-            .unitId(getUser().getValdVardenhet().getId())
-            .careProviderId(getUser().getValdVardgivare().getId())
-            .origin(getUser().getOrigin())
-            .build();
-    }
-
-    private static String role(Map<String, Role> roles) {
-        return roles != null && roles.size() == 1 ? roles.keySet().iterator().next() : null;
+        return loggedInWebcertUserFactory.create(user);
     }
 }

--- a/web/src/test/java/se/inera/intyg/webcert/web/service/user/LoggedInWebcertUserFactoryTest.java
+++ b/web/src/test/java/se/inera/intyg/webcert/web/service/user/LoggedInWebcertUserFactoryTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025 Inera AB (http://www.inera.se)
+ *
+ * This file is part of sklintyg (https://github.com/sklintyg).
+ *
+ * sklintyg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * sklintyg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.inera.intyg.webcert.web.service.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.inera.intyg.infra.integration.hsatk.model.legacy.Mottagning;
+import se.inera.intyg.infra.integration.hsatk.model.legacy.Vardgivare;
+import se.inera.intyg.infra.security.common.model.IntygUser;
+import se.inera.intyg.infra.security.common.model.Role;
+import se.inera.intyg.webcert.web.service.user.dto.WebCertUser;
+
+@ExtendWith(MockitoExtension.class)
+class LoggedInWebcertUserFactoryTest {
+
+    @InjectMocks
+    private LoggedInWebcertUserFactory factory;
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateFromIntygUser {
+
+        private IntygUser intygUser;
+
+        @BeforeEach
+        void setUp() {
+            intygUser = mock(IntygUser.class);
+        }
+
+        @Test
+        void shallIncludeStaffId() {
+            final var expected = "staffId";
+            when(intygUser.getHsaId()).thenReturn(expected);
+
+            final var actual = factory.create(intygUser);
+            assertEquals(expected, actual.getStaffId());
+        }
+
+        @Test
+        void shallIncludeUnitId() {
+            final var expected = "unitId";
+            when(intygUser.getValdVardenhet()).thenReturn(new Mottagning(expected, "testenhet"));
+
+            final var actual = factory.create(intygUser);
+            assertEquals(expected, actual.getUnitId());
+        }
+
+        @Test
+        void shallIncludeCareProviderId() {
+            final var expected = "careProviderId";
+            when(intygUser.getValdVardgivare()).thenReturn(new Vardgivare(expected, "testvårdgivare"));
+
+            final var actual = factory.create(intygUser);
+            assertEquals(expected, actual.getCareProviderId());
+        }
+
+        @Test
+        void shallIncludeRoleWhenSingleRole() {
+            final var expected = "role";
+            when(intygUser.getRoles()).thenReturn(Map.of(expected, new Role()));
+
+            final var actual = factory.create(intygUser);
+            assertEquals(expected, actual.getRole());
+        }
+
+        @Test
+        void shallNotIncludeOrigin() {
+            final var actual = factory.create(intygUser);
+            assertNull(actual.getOrigin(), "Origin shall not be included when creating from IntygUser");
+            verify(intygUser, never()).getOrigin();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CreateFromWebCertUser {
+
+        private WebCertUser webCertUser;
+
+        @BeforeEach
+        void setUp() {
+            webCertUser = mock(WebCertUser.class);
+        }
+
+        @Test
+        void shallIncludeStaffId() {
+            final var expected = "staffId";
+            when(webCertUser.getHsaId()).thenReturn(expected);
+
+            final var actual = factory.create(webCertUser);
+            assertEquals(expected, actual.getStaffId());
+        }
+
+        @Test
+        void shallIncludeUnitId() {
+            final var expected = "unitId";
+            when(webCertUser.getValdVardenhet()).thenReturn(new Mottagning(expected, "testenhet"));
+
+            final var actual = factory.create(webCertUser);
+            assertEquals(expected, actual.getUnitId());
+        }
+
+        @Test
+        void shallIncludeCareProviderId() {
+            final var expected = "careProviderId";
+            when(webCertUser.getValdVardgivare()).thenReturn(new Vardgivare(expected, "testvårdgivare"));
+
+            final var actual = factory.create(webCertUser);
+            assertEquals(expected, actual.getCareProviderId());
+        }
+
+        @Test
+        void shallIncludeRoleWhenSingleRole() {
+            final var expected = "role";
+            when(webCertUser.getRoles()).thenReturn(Map.of(expected, new Role()));
+
+            final var actual = factory.create(webCertUser);
+            assertEquals(expected, actual.getRole());
+        }
+
+        @Test
+        void shallIncludeOrigin() {
+            final var expected = "origin";
+            when(webCertUser.getOrigin()).thenReturn(expected);
+
+            final var actual = factory.create(webCertUser);
+            assertEquals(expected, actual.getOrigin());
+        }
+    }
+}


### PR DESCRIPTION
Publishing events for wc and cs certificates when created through CreateDraftCertificate. To handle if prefill or not a different message type has been added (DRAFT_CREATED_WITH_PREFILL).

Fixed an issue where sessionId is "-", due to the fact that webcert has a filter that sets sessionId to "-" when no user is logged. 